### PR TITLE
Change header order so setup.py works on OS X.

### DIFF
--- a/threeML/models/pyToCppModelInterface.h
+++ b/threeML/models/pyToCppModelInterface.h
@@ -8,13 +8,14 @@
 #ifndef PYTOCPPMODEL_INTERFACE_H
 #define PYTOCPPMODEL_INTERFACE_H
 
+#include <boost/python.hpp>
+
+#include <Python.h>
+
 #include "ModelInterface.h"
 #include <vector>
 #include <map>
 #include <string>
-
-#include <Python.h>
-#include <boost/python.hpp>
 
 namespace threeML {
     


### PR DESCRIPTION
Hi Giacomo et al., I had to change the order of the includes in threeML/models/pyToCppModelInterface.h in order to get setup.py to build on OS X.  You may want to copy the change to the master.