### PR TITLE
Switch LiFF module name to liff_3ML.

### DIFF
--- a/threeML/plugins/HAWCLike.py
+++ b/threeML/plugins/HAWCLike.py
@@ -6,7 +6,7 @@ from threeML.io.fileUtils import fileExistingAndReadable, sanitizeFilename
 
 from threeML.pyModelInterface import pyToCppModelInterface
 
-from hawc import liff
+from hawc import liff_3ML
 
 import os, sys, collections
 
@@ -174,13 +174,13 @@ class HAWCLike( pluginPrototype ):
             #Load all sky
             #(ROI will be defined later)
             
-            self.theLikeHAWC = liff.LikeHAWC( self.maptree, 
-                                              self.ntransits,
-                                              self.response,
-                                              self.pymodel,
-                                              self.minChannel,
-                                              self.maxChannel,
-                                              self.fullsky )
+            self.theLikeHAWC = liff_3ML.LikeHAWC(self.maptree, 
+                                                 self.ntransits,
+                                                 self.response,
+                                                 self.pymodel,
+                                                 self.minChannel,
+                                                 self.maxChannel,
+                                                 self.fullsky)
             
             if self.roi_ra is None and self.fullsky:
                 


### PR DESCRIPTION
I altered the bindings in AERIE so that there is now a liff_3ML module that works with 3ML, and a separate liff module with bindings that may clash with threeML. This change makes sure the HAWCLike plugin loads the liff_3ML module.