### PR TITLE
fix simulated OGIP constructor issue

### DIFF
--- a/threeML/plugins/OGIPLike.py
+++ b/threeML/plugins/OGIPLike.py
@@ -437,13 +437,24 @@ class OGIPLike(PluginPrototype):
 
             # Now create another instance of OGIPLike with the randomized data we just generated
 
-            new_ogip_like = type(self)(new_name,
-                                       pha_file=pha,
-                                       bak_file=bak,
-                                       rsp_file=self._rsp,  # Use the currently loaded response so we don't need to
-                                                            # re-read from disk (way faster!)
-                                       arf_file=None,       # The ARF is None because if present has been already read in
-                                                            # the self._rsp class
+            # new_ogip_like = type(self)(new_name,
+            #                            pha_file=pha,
+            #                            bak_file=bak,
+            #                            rsp_file=self._rsp,  # Use the currently loaded response so we don't need to
+            #                                                 # re-read from disk (way faster!)
+            #                            arf_file=None,       # The ARF is None because if present has been already read in
+            #                                                 # the self._rsp class
+            #                            verbose=self._verbose)
+
+            # Switch to using a generic ogip like because the constructor for
+            # different instruments will vary.
+            new_ogip_like = OGIPLike(new_name,
+                                     pha_file=pha,
+                                     bak_file=bak,
+                                     rsp_file=self._rsp,  # Use the currently loaded response so we don't need to
+                                     # re-read from disk (way faster!)
+                                     arf_file=None,  # The ARF is None because if present has been already read in
+                                     # the self._rsp class
                                        verbose=self._verbose)
 
             # Apply the same selections as the current data set


### PR DESCRIPTION
I noticed that since inherited OGIPLike plugins could have a different constructor than the generic OGIPLike, it would result in an error (e.g. TTELike has no arf_file arg.) So I switched this to  OGIPLike since the extra inherited stuff *should* only be data handling and not the core PHA info.