### PR TITLE
Importing HAWCLike was causing an error because the hawn module was n…

### DIFF
--- a/threeML/test/test_hawc.py
+++ b/threeML/test/test_hawc.py
@@ -2,7 +2,18 @@ import pytest
 
 from threeML import *
 
-from threeML.plugins.HAWCLike import HAWCLike
+try:
+
+    from threeML.plugins.HAWCLike import HAWCLike
+
+except(ImportError):
+
+    pass
+
+
+
+
+
 from threeML.io.file_utils import sanitize_filename
 
 # This defines a decorator which can be applied to single tests to


### PR DESCRIPTION
…o available


I have simply added an import trial and exception. 