### PR TITLE
Save event list background

### DIFF
--- a/threeML/plugins/EventListLike.py
+++ b/threeML/plugins/EventListLike.py
@@ -292,9 +292,20 @@ class EventListLike(OGIPLike):
         return self._evt_list.get_poly_info()
 
 
+    def save_background(self,filename, overwrite=False):
+        """
+
+        save the background to and HDF5 file. The filename does not need an extension.
+        The filename will be saved as <filename>_bkg.h5
 
 
 
+        :param filename: name of file to save
+        :param overwrite: to overwrite or not
+        :return:
+        """
+
+        self._evt_list.save_background(filename,overwrite)
 
 
 

--- a/threeML/plugins/EventListLike.py
+++ b/threeML/plugins/EventListLike.py
@@ -2,6 +2,12 @@ __author__ = 'grburgess'
 
 import numpy as np
 
+from threeML.io.file_utils import file_existing_and_readable
+import pandas as pd
+import os
+from pandas import HDFStore
+from threeML.io.file_utils import sanitize_filename
+
 from threeML.exceptions.custom_exceptions import custom_warnings, NegativeBackground
 
 try:
@@ -35,11 +41,13 @@ class BinningMethodError(RuntimeError):
 
 
 class EventListLike(OGIPLike):
-    def __init__(self, name, event_list, background_selections, source_intervals, rsp_file,
-                 poly_order=-1, unbinned=True, verbose=True):
+    def __init__(self, name, event_list, rsp_file, source_intervals, background_selections=None,
+                 poly_order=-1, unbinned=True, verbose=True,restore_poly_fit=None):
         """
         Generic EventListLike that should be inherited
         """
+
+        assert (background_selections is not None) or (restore_poly_fit is not None), "you specify background selections or a restore file"
 
         self._evt_list = event_list
 
@@ -55,10 +63,47 @@ class EventListLike(OGIPLike):
         self._startup = True  # This keeps things from being called twice!
 
         source_intervals = [interval.replace(' ', '') for interval in source_intervals.split(',')]
-        background_selections = [interval.replace(' ', '') for interval in background_selections.split(',')]
+
 
         self.set_active_time_interval(*source_intervals)
-        self.set_background_interval(*background_selections, unbinned=unbinned)
+
+        if restore_poly_fit is None:
+
+            background_selections = [interval.replace(' ', '') for interval in background_selections.split(',')]
+
+            self.set_background_interval(*background_selections, unbinned=unbinned)
+
+        else:
+
+            if file_existing_and_readable(restore_poly_fit):
+
+                self._evt_list.restore_fit(restore_poly_fit)
+
+                # In theory this will automatically get the poly counts if a
+                # time interval already exists
+
+                self._bkg_pha = self._evt_list.get_pha_container(use_poly=True)
+
+
+
+            else:
+
+                if background_selections is None:
+
+                    raise RuntimeError("Could not find saved background %s and no background_selections specified" % restore_poly_fit)
+
+                else:
+
+                    custom_warnings.warn("Could not find saved background %s. Fitting background manually" % restore_poly_fit)
+
+                    background_selections = [interval.replace(' ', '') for interval in background_selections.split(',')]
+
+                    self.set_background_interval(*background_selections, unbinned=unbinned)
+
+
+
+
+
 
         # Keeps track of if we are beginning
         self._startup = False
@@ -186,8 +231,11 @@ class EventListLike(OGIPLike):
         self._bkg_pha = self._evt_list.get_pha_container(use_poly=True)
 
         if not self._startup:
-            OGIPLike.__init__(self, self.name, pha_file=self._observed_pha, bak_file=self._bkg_pha,
-                              rsp_file=self._rsp_file, verbose=self._verbose)
+            super(EventListLike, self).__init__(self.name,
+                                                pha_file=self._observed_pha,
+                                                bak_file=self._bkg_pha,
+                                                rsp_file=self._rsp_file,
+                                                verbose=self._verbose)
 
     def view_lightcurve(self, start=-10, stop=60., dt=1., use_binner=False, energy_selection=None):
         """ stub """
@@ -242,6 +290,15 @@ class EventListLike(OGIPLike):
         """
 
         return self._evt_list.get_poly_info()
+
+
+
+
+
+
+
+
+
 
     @property
     def text_bins(self):

--- a/threeML/plugins/FermiGBMTTELike.py
+++ b/threeML/plugins/FermiGBMTTELike.py
@@ -22,7 +22,7 @@ class BinningMethodError(RuntimeError):
 
 class FermiGBMTTELike(EventListLike):
 
-    def __init__(self, name, tte_file, background_selections, source_intervals, rsp_file, trigger_time=None,
+    def __init__(self, name, tte_file, rsp_file, source_intervals, background_selections=None,restore_background=None,trigger_time=None,
                  poly_order=-1, unbinned=True, verbose=True):
         """
         A plugin to natively bin, view, and handle Fermi GBM TTE data.
@@ -101,8 +101,15 @@ class FermiGBMTTELike(EventListLike):
 
         # pass to the super class
 
-        EventListLike.__init__(self, name, event_list, background_selections, source_intervals, rsp_file,
-                               poly_order, unbinned, verbose)
+        super(FermiGBMTTELike, self).__init__(name,
+                                              event_list,
+                                              rsp_file=rsp_file,
+                                              source_intervals=source_intervals,
+                                              background_selections=background_selections,
+                                              poly_order=poly_order,
+                                              unbinned=unbinned,
+                                              verbose=verbose,
+                                              restore_poly_fit=restore_background)
 
     def set_active_time_interval(self, *intervals, **kwargs):
         """

--- a/threeML/plugins/FermiLATLLELike.py
+++ b/threeML/plugins/FermiLATLLELike.py
@@ -22,8 +22,8 @@ class BinningMethodError(RuntimeError):
 
 
 class FermiLATLLELike(EventListLike):
-    def __init__(self, name, lle_file, ft2_file, background_selections, source_intervals, rsp_file, trigger_time=None,
-                 poly_order=-1, unbinned=False, verbose=True):
+    def __init__(self, name, lle_file, ft2_file, rsp_file, source_intervals, background_selections=None, restore_background=None,
+                 trigger_time=None, poly_order=-1, unbinned=False, verbose=True):
         """
         A plugin to natively bin, view, and handle Fermi LAT LLE data.
         An LLE event file and FT2 (1 sec) are required as well as the associated response
@@ -86,8 +86,17 @@ class FermiLATLLELike(EventListLike):
                 mission=self._lat_lle_file.mission,
                 verbose=verbose)
 
-        super(FermiLATLLELike,self).__init__( name, event_list, background_selections, source_intervals, rsp_file,
-                               poly_order, unbinned, verbose)
+        super(FermiLATLLELike,self).__init__(name,
+                                             event_list,
+                                             rsp_file=rsp_file,
+                                             source_intervals=source_intervals,
+                                             background_selections=background_selections,
+                                             poly_order=poly_order,
+                                             unbinned=unbinned,
+                                             verbose=verbose,
+                                             restore_poly_fit=restore_background
+                                             )
+
 
 
 

--- a/threeML/plugins/OGIP/event_polynomial.py
+++ b/threeML/plugins/OGIP/event_polynomial.py
@@ -37,6 +37,15 @@ class Polynomial(object):
 
             self._integral_polynomial = Polynomial(integral_coeff, is_integral=True)
 
+    @classmethod
+    def from_previous_fit(cls, coefficients, covariance):
+
+
+        poly = Polynomial(coefficients=coefficients)
+        poly._cov_matrix = covariance
+
+        return poly
+
     @property
     def degree(self):
         """

--- a/threeML/plugins/OGIP/eventlist.py
+++ b/threeML/plugins/OGIP/eventlist.py
@@ -1121,10 +1121,11 @@ class EventList(object):
 
             else:
 
-                raise IOError("The file %s already exists! You cannot call two different "
-                              "template models with the same name" % filename_sanitized)
+                raise IOError("The file %s already exists!" % filename_sanitized)
 
         with HDFStore(filename_sanitized) as store:
+
+            # extract the polynomial information and save it
 
             if self._poly_fit_exists:
 
@@ -1165,6 +1166,8 @@ class EventList(object):
 
             self._polynomials = []
 
+            # create new polynomials
+
             for i in range(len(coefficients)):
 
                 coeff = np.array(coefficients.loc[i])
@@ -1189,6 +1192,8 @@ class EventList(object):
             self._optimal_polynomial_grade = metadata['poly_order']
             self._poly_time_selections = metadata['poly_selections']
             self._unbinned = metadata['unbinned']
+
+        # go thru and count the counts!
 
         self._poly_fit_exists = True
 

--- a/threeML/plugins/OGIP/eventlist.py
+++ b/threeML/plugins/OGIP/eventlist.py
@@ -1,14 +1,18 @@
 # Creates a generic event list reader that can create PHA objects on the fly
 
 import numpy as np
-
+import os
 import re
 
 import copy
 import pandas as pd
+from pandas import HDFStore
+
+
 
 from threeML.io.rich_display import display
 from threeML.utils.stats_tools import Significance
+from threeML.io.file_utils import sanitize_filename
 
 from threeML.parallel.parallel_client import ParallelClient
 from threeML.config.config import threeML_config
@@ -16,7 +20,8 @@ from threeML.exceptions.custom_exceptions import custom_warnings
 from threeML.io.progress_bar import progress_bar
 from threeML.utils.binner import TemporalBinner
 
-from event_polynomial import polyfit, unbinned_polyfit
+
+from event_polynomial import polyfit, unbinned_polyfit, Polynomial
 
 from threeML.plugins.OGIP.pha import PHAContainer
 
@@ -1076,6 +1081,124 @@ class EventList(object):
 
 
         self._polynomials = polynomials
+
+
+    def save_background(self, filename, overwrite=False):
+        """
+        save the background to an HD5F
+
+        :param filename:
+        :return:
+        """
+
+        # make the file name proper
+
+        filename_split = filename.split('.')
+
+        if len(filename_split) > 1:
+
+            filename = "%s_saved_bkg.h5" % ''.join(filename_split[:-1])
+
+        else:
+
+            filename = "%s_saved_bkg.h5" % ''.join(filename_split[0])
+
+        filename_sanitized = sanitize_filename(filename)
+
+        # Check that it does not exists
+        if os.path.exists(filename_sanitized):
+
+            if overwrite:
+
+                try:
+
+                    os.remove(filename_sanitized)
+
+                except:
+
+                    raise IOError("The file %s already exists and cannot be removed (maybe you do not have "
+                                  "permissions to do so?). " % filename_sanitized)
+
+            else:
+
+                raise IOError("The file %s already exists! You cannot call two different "
+                              "template models with the same name" % filename_sanitized)
+
+        with HDFStore(filename_sanitized) as store:
+
+            if self._poly_fit_exists:
+
+                coeff = []
+                err = []
+
+                for poly in self._polynomials:
+                    coeff.append(poly.coefficients)
+                    err.append(poly.covariance_matrix)
+                df_coeff = pd.DataFrame(coeff)
+                df_err = pd.DataFrame(err)
+
+            else:
+
+                raise RuntimeError('the polynomials have not been fit yet')
+
+            df_coeff.to_hdf(store, 'coefficients')
+            df_err.to_hdf(store, 'covariance')
+
+
+
+            store.get_storer('coefficients').attrs.metadata = {'poly_order': self._optimal_polynomial_grade,
+                                                             'poly_selections': self._poly_time_selections,
+                                                             'unbinned':self._unbinned}
+
+    def restore_fit(self, filename):
+
+
+        filename_sanitized = sanitize_filename(filename)
+
+        with HDFStore(filename_sanitized) as store:
+
+            coefficients = store['coefficients']
+
+
+
+            covariance = store['covariance']
+
+            self._polynomials = []
+
+            for i in range(len(coefficients)):
+
+                coeff = np.array(coefficients.loc[i])
+
+                # make sure we get the right order
+                # pandas stores the non-needed coeff
+                # as nans.
+
+                coeff = coeff[np.isfinite(coeff)]
+
+                cov  = covariance.loc[i][0]
+
+
+
+                self._polynomials.append(Polynomial.from_previous_fit(coeff, cov))
+
+
+
+
+            metadata = store.get_storer('coefficients').attrs.metadata
+
+            self._optimal_polynomial_grade = metadata['poly_order']
+            self._poly_time_selections = metadata['poly_selections']
+            self._unbinned = metadata['unbinned']
+
+        self._poly_fit_exists = True
+
+        if self._time_selection_exists:
+
+            tmp = []
+            for tmin, tmax in zip(self._tmin_list, self._tmax_list):
+                tmp.append("%.5f-%.5f" % (tmin, tmax))
+
+            self.set_active_time_intervals(*tmp)
 
 
 class EventListWithDeadTime(EventList):

--- a/threeML/test/test_gbm.py
+++ b/threeML/test/test_gbm.py
@@ -150,9 +150,10 @@ def test_gbm_tte_constructor():
 
         nai3 = FermiGBMTTELike('NAI3',
                                os.path.join(data_dir, "glg_tte_n3_bn080916009_v01.fit.gz"),
-                               "-10-0, 100-150",
-                               src_selection,
-                               rsp_file=os.path.join(data_dir, "glg_cspec_n3_bn080916009_v00.rsp2"), poly_order=-1)
+                               rsp_file=os.path.join(data_dir, "glg_cspec_n3_bn080916009_v00.rsp2"),
+                               source_intervals=src_selection,
+                               background_selections="-10-0, 100-150",
+                               poly_order=-1)
 
         assert nai3.name == 'NAI3'
 
@@ -187,9 +188,10 @@ def test_gbm_binning():
 
         nai3 = FermiGBMTTELike('NAI3',
                                os.path.join(data_dir, "glg_tte_n3_bn080916009_v01.fit.gz"),
-                               "-10-0, 100-150",
-                               src_selection,
-                               rsp_file=os.path.join(data_dir, "glg_cspec_n3_bn080916009_v00.rsp2"), poly_order=-1)
+                               rsp_file=os.path.join(data_dir, "glg_cspec_n3_bn080916009_v00.rsp2"),
+                               source_intervals=src_selection,
+                               background_selections="-10-0, 100-150",
+                               poly_order=-1)
 
         # should not have bins yet
 
@@ -262,9 +264,10 @@ def test_gbm_tte_joint_likelihood_fitting():
 
         nai3 = FermiGBMTTELike('NAI3',
                                os.path.join(data_dir, "glg_tte_n3_bn080916009_v01.fit.gz"),
-                               "-10-0, 100-150",
-                               src_selection,
-                               rsp_file=os.path.join(data_dir, "glg_cspec_n3_bn080916009_v00.rsp2"), poly_order=1)
+                               rsp_file=os.path.join(data_dir, "glg_cspec_n3_bn080916009_v00.rsp2"),
+                               source_intervals=src_selection,
+                               background_selections="-10-0, 100-150",
+                               poly_order=-1)
 
         ab = AnalysisBuilder(nai3)
 
@@ -307,9 +310,10 @@ def test_gbm_tte_bayesian_fitting():
 
         nai3 = FermiGBMTTELike('NAI3',
                                os.path.join(data_dir, "glg_tte_n3_bn080916009_v01.fit.gz"),
-                               "-10-0, 100-150",
-                               src_selection,
-                               rsp_file=os.path.join(data_dir, "glg_cspec_n3_bn080916009_v00.rsp2"), poly_order=1)
+                               rsp_file=os.path.join(data_dir, "glg_cspec_n3_bn080916009_v00.rsp2"),
+                               source_intervals=src_selection,
+                               background_selections="-10-0, 100-150",
+                               poly_order=-1)
 
         ab = AnalysisBuilder(nai3)
         ab.set_priors()
@@ -340,6 +344,38 @@ def test_gbm_tte_bayesian_fitting():
 
             assert bb.raw_samples.shape == (n_samples, 2)
 
+
+
+
+def test_saving_background():
+    with within_directory(__example_dir):
+        data_dir = os.path.join('gbm', 'bn080916009')
+
+        src_selection = "0.-10."
+
+        nai3 = FermiGBMTTELike('NAI3',
+                               os.path.join(data_dir, "glg_tte_n3_bn080916009_v01.fit.gz"),
+                               rsp_file=os.path.join(data_dir, "glg_cspec_n3_bn080916009_v00.rsp2"),
+                               source_intervals=src_selection,
+                               background_selections="-10-0, 100-150",
+                               poly_order=-1)
+
+        old_coeffcients , old_errors = nai3.get_background_parameters()
+
+        nai3.save_background('temp_gbm',overwrite=True)
+
+        nai3 = FermiGBMTTELike('NAI3',
+                               os.path.join(data_dir, "glg_tte_n3_bn080916009_v01.fit.gz"),
+                               rsp_file=os.path.join(data_dir, "glg_cspec_n3_bn080916009_v00.rsp2"),
+                               source_intervals=src_selection,
+                               restore_background='temp_gbm_saved_bkg.h5',
+                               poly_order=-1)
+
+        new_coeffcients, new_errors = nai3.get_background_parameters()
+
+        assert new_coeffcients == old_coeffcients
+
+        assert new_errors == old_errors
 
 
 

--- a/threeML/test/test_lle.py
+++ b/threeML/test/test_lle.py
@@ -140,10 +140,11 @@ def test_lle_constructor():
         src_selection = "0.-10."
 
         lle = FermiLATLLELike('lle', os.path.join(data_dir, "gll_lle_bn080916009_v10.fit"),
-                               os.path.join(data_dir, "gll_pt_bn080916009_v10.fit"),
-                               "-100--1, 100-200",
-                               src_selection,
-                               rsp_file=os.path.join(data_dir, "gll_cspec_bn080916009_v10.rsp"), poly_order=-1)
+                              os.path.join(data_dir, "gll_pt_bn080916009_v10.fit"),
+                              rsp_file=os.path.join(data_dir, "gll_cspec_bn080916009_v10.rsp"),
+                              source_intervals=src_selection,
+                              background_selections="-100--1, 100-200",
+                              poly_order=-1)
 
         assert lle.name == 'lle'
 
@@ -175,11 +176,13 @@ def test_lle_binning():
 
         src_selection = "0.-10."
 
+
         lle = FermiLATLLELike('lle', os.path.join(data_dir, "gll_lle_bn080916009_v10.fit"),
-                               os.path.join(data_dir, "gll_pt_bn080916009_v10.fit"),
-                               "-100-0, 100-200",
-                               src_selection,
-                               rsp_file=os.path.join(data_dir, "gll_cspec_bn080916009_v10.rsp"), poly_order=-1)
+                              os.path.join(data_dir, "gll_pt_bn080916009_v10.fit"),
+                              rsp_file=os.path.join(data_dir, "gll_cspec_bn080916009_v10.rsp"),
+                              source_intervals=src_selection,
+                              background_selections="-100--1, 100-200",
+                              poly_order=-1)
         # should not have bins yet
 
         with pytest.raises(AttributeError):
@@ -239,11 +242,13 @@ def test_lle_joint_likelihood_fitting():
 
         src_selection = "0.-70."
 
+
         lle = FermiLATLLELike('lle', os.path.join(data_dir, "gll_lle_bn080916009_v10.fit"),
-                               os.path.join(data_dir, "gll_pt_bn080916009_v10.fit"),
-                               "-100-0, 100-200",
-                               src_selection,
-                               rsp_file=os.path.join(data_dir, "gll_cspec_bn080916009_v10.rsp"), poly_order=-1)
+                              os.path.join(data_dir, "gll_pt_bn080916009_v10.fit"),
+                              rsp_file=os.path.join(data_dir, "gll_cspec_bn080916009_v10.rsp"),
+                              source_intervals=src_selection,
+                              background_selections="-100--1, 100-200",
+                              poly_order=-1)
 
         lle.set_active_measurements("50000-100000")
 
@@ -280,11 +285,13 @@ def test_lle_bayesian_fitting():
 
         src_selection = "0.-10."
 
+
         lle = FermiLATLLELike('lle', os.path.join(data_dir, "gll_lle_bn080916009_v10.fit"),
-                               os.path.join(data_dir, "gll_pt_bn080916009_v10.fit"),
-                               "-100-0, 100-200",
-                               src_selection,
-                               rsp_file=os.path.join(data_dir, "gll_cspec_bn080916009_v10.rsp"), poly_order=-1)
+                              os.path.join(data_dir, "gll_pt_bn080916009_v10.fit"),
+                              rsp_file=os.path.join(data_dir, "gll_cspec_bn080916009_v10.rsp"),
+                              source_intervals=src_selection,
+                              background_selections="-100--1, 100-200",
+                              poly_order=-1)
 
 
 
@@ -317,3 +324,33 @@ def test_lle_bayesian_fitting():
 
             assert bb.raw_samples.shape == (n_samples, 2)
 
+
+def test_save_background():
+    with within_directory(__example_dir):
+        data_dir = 'lat'
+
+        src_selection = "0.-10."
+
+        lle = FermiLATLLELike('lle', os.path.join(data_dir, "gll_lle_bn080916009_v10.fit"),
+                              os.path.join(data_dir, "gll_pt_bn080916009_v10.fit"),
+                              rsp_file=os.path.join(data_dir, "gll_cspec_bn080916009_v10.rsp"),
+                              source_intervals=src_selection,
+                              background_selections="-100--1, 100-200",
+                              poly_order=-1)
+
+        old_coeffcients, old_errors = lle.get_background_parameters()
+
+        lle.save_background('temp_lle', overwrite=True)
+
+        lle = FermiLATLLELike('lle', os.path.join(data_dir, "gll_lle_bn080916009_v10.fit"),
+                              os.path.join(data_dir, "gll_pt_bn080916009_v10.fit"),
+                              rsp_file=os.path.join(data_dir, "gll_cspec_bn080916009_v10.rsp"),
+                              source_intervals=src_selection,
+                              restore_background='temp_lle_saved_bkg.h5')
+
+
+        new_coeffcients, new_errors = lle.get_background_parameters()
+
+        assert new_coeffcients == old_coeffcients
+
+        assert new_errors == old_errors


### PR DESCRIPTION
Introduces a method to save the background fits from event lists to an HDF5 file so that the fit can be quickly restored. This is useful in the event that you want to quickly refit many EventListLike objects repeatedly. 

Also, reordered the argument call to TTELike, LLELike and EventListLike to make more sense... sorry!

Tests written as well. 