### PR TITLE
fix double download of compressed file

### DIFF
--- a/threeML/io/download_from_http.py
+++ b/threeML/io/download_from_http.py
@@ -124,7 +124,6 @@ class ApacheDirectory(object):
         # If no filename is specified, use the same name that the file has on the remote server
 
         if new_filename is None:
-
             new_filename = remote_filename.split("/")[-1]
 
         # Get the fully qualified path for the remote and the local file
@@ -145,11 +144,19 @@ class ApacheDirectory(object):
         file_size = int(this_request.headers['Content-Length'])
 
         # Now check if we really need to download this file
+
+        if compress:
+            # Add a .gz at the end of the file path
+
+            local_path += '.gz'
+
         if file_existing_and_readable(local_path):
 
             local_size = os.path.getsize(local_path)
 
-            if local_size == file_size:
+            if local_size == file_size or compress:
+                # if the compressed file already exists
+                # it will have a smaller size
 
                 # No need to download it again
                 return local_path
@@ -164,8 +171,8 @@ class ApacheDirectory(object):
 
             opener = gzip.open
 
-            # Add a .gz at the end of the file path
-            local_path += '.gz'
+
+
 
         else:
 
@@ -176,7 +183,8 @@ class ApacheDirectory(object):
             # Set a title for the progress bar
             bar_title = "Downloading %s" % new_filename
 
-            with progress_bar(file_size, scale=1024*1024, units='Mb', title=bar_title) as bar:  # type: ProgressBarBase
+            with progress_bar(file_size, scale=1024 * 1024, units='Mb',
+                              title=bar_title) as bar:  # type: ProgressBarBase
 
                 with opener(local_path, 'wb') as f:
 


### PR DESCRIPTION
I included this fix bundled with the model plotting. It keeps the downloader from re-downloading files that are compressed on the disk because the file size is different ;)