### PR TITLE
checking for both unicode and str type when reading RSP

### DIFF
--- a/threeML/plugins/OGIPLike.py
+++ b/threeML/plugins/OGIPLike.py
@@ -75,7 +75,7 @@ class OGIPLike(PluginPrototype):
 
         # Read in the response
 
-        if isinstance(rsp_file, str):
+        if isinstance(rsp_file, str) or isinstance(rsp_file, unicode):
 
             self._rsp = OGIPResponse(rsp_file, arf_file=arf_file)
 


### PR DESCRIPTION
Sometimes a file name can be unicode and it will not cause an OGIPResponse to be built. This adds a check for a unicode type.