### PR TITLE
allow for force write of rsps

### DIFF
--- a/threeML/plugins/DispersionSpectrumLike.py
+++ b/threeML/plugins/DispersionSpectrumLike.py
@@ -104,7 +104,7 @@ class DispersionSpectrumLike(SpectrumLike):
 
         return super_out.append(the_df)
 
-    def write_pha(self, filename, overwrite=False):
+    def write_pha(self, filename, overwrite=False, force_rsp_write=False):
         """
 
         :param filename:
@@ -120,4 +120,4 @@ class DispersionSpectrumLike(SpectrumLike):
         from threeML.plugins.OGIPLike import OGIPLike
 
         ogiplike = OGIPLike.from_general_dispersion_spectrum(self)
-        ogiplike.write_pha(file_name=filename, overwrite=overwrite)
+        ogiplike.write_pha(file_name=filename, overwrite=overwrite, force_rsp_write=force_rsp_write)

--- a/threeML/plugins/DispersionSpectrumLike.py
+++ b/threeML/plugins/DispersionSpectrumLike.py
@@ -106,10 +106,12 @@ class DispersionSpectrumLike(SpectrumLike):
 
     def write_pha(self, filename, overwrite=False, force_rsp_write=False):
         """
+        Writes the observation, background and (optional) rsp to PHAII fits files
 
-        :param filename:
-        :param overwrite:
-        :return:
+        :param filename: base file name to write out
+        :param overwrite: if you would like to force overwriting of the files
+        :param force_rsp_write: force the writing of an rsp even if not required
+
         """
 
         # we need to pass up the variables to an OGIPLike

--- a/threeML/plugins/OGIP/pha.py
+++ b/threeML/plugins/OGIP/pha.py
@@ -58,7 +58,7 @@ class PHAWrite(object):
 
         self._spec_iterator = 1
 
-    def write(self, outfile_name, overwrite=True):
+    def write(self, outfile_name, overwrite=True, force_rsp_write=False):
         """
         Write a PHA Type II and BAK file for the given OGIP plugin. Automatically determines
         if BAK files should be generated.
@@ -68,6 +68,8 @@ class PHAWrite(object):
         :param overwrite: (optional) bool to overwrite existing file
         :return:
         """
+
+        self._force_rsp_write = force_rsp_write
 
         # Remove the .pha extension if any
         if os.path.splitext(outfile_name)[-1].lower() == '.pha':
@@ -81,6 +83,9 @@ class PHAWrite(object):
         for ogip in self._ogiplike:
 
             self._append_ogip(ogip)
+
+
+
 
         self._write_phaII(overwrite)
 
@@ -130,7 +135,7 @@ class PHAWrite(object):
                 self._ancrfile[key].append('NONE')
 
 
-            if pha_info['rsp'].rsp_filename is not None:
+            if pha_info['rsp'].rsp_filename is not None and not self._force_rsp_write:
 
                 self._respfile[key].append(pha_info['rsp'].rsp_filename)
 

--- a/threeML/plugins/OGIP/pha.py
+++ b/threeML/plugins/OGIP/pha.py
@@ -95,6 +95,7 @@ class PHAWrite(object):
         Add an ogip instance's data into the data list
 
         :param ogip: and OGIPLike instance
+        :param force_rsp_write: force the writing of an rsp
         :return: None
         """
 

--- a/threeML/plugins/OGIP/pha.py
+++ b/threeML/plugins/OGIP/pha.py
@@ -83,7 +83,7 @@ class PHAWrite(object):
 
         for ogip in self._ogiplike:
 
-            self._append_ogip(ogip)
+            self._append_ogip(ogip, force_rsp_write)
 
 
 

--- a/threeML/plugins/OGIP/pha.py
+++ b/threeML/plugins/OGIP/pha.py
@@ -66,10 +66,11 @@ class PHAWrite(object):
 
         :param outfile_name: string (excluding .pha) of the PHA to write
         :param overwrite: (optional) bool to overwrite existing file
+        :param force_rsp_write: force the writing of an RSP
         :return:
         """
 
-        self._force_rsp_write = force_rsp_write
+
 
         # Remove the .pha extension if any
         if os.path.splitext(outfile_name)[-1].lower() == '.pha':
@@ -89,7 +90,7 @@ class PHAWrite(object):
 
         self._write_phaII(overwrite)
 
-    def _append_ogip(self, ogip):
+    def _append_ogip(self, ogip, force_rsp_write):
         """
         Add an ogip instance's data into the data list
 
@@ -135,7 +136,7 @@ class PHAWrite(object):
                 self._ancrfile[key].append('NONE')
 
 
-            if pha_info['rsp'].rsp_filename is not None and not self._force_rsp_write:
+            if pha_info['rsp'].rsp_filename is not None and not force_rsp_write:
 
                 self._respfile[key].append(pha_info['rsp'].rsp_filename)
 

--- a/threeML/plugins/OGIPLike.py
+++ b/threeML/plugins/OGIPLike.py
@@ -97,18 +97,21 @@ class OGIPLike(DispersionSpectrumLike):
 
         return self._observed_spectrum.grouping
 
-    def write_pha(self, file_name, overwrite=False):
+    def write_pha(self, file_name, overwrite=False, force_rsp_write=False):
         """
         Create a pha file of the current pha selections
 
 
         :param file_name: output file name (excluding extension)
+        :param overwrite: overwrite the files
+        :param force_rsp_write: for an rsp to be saved
+
         :return: None
         """
 
         pha_writer = PHAWrite(self)
 
-        pha_writer.write(file_name, overwrite=overwrite)
+        pha_writer.write(file_name, overwrite=overwrite, force_rsp_write=force_rsp_write)
 
     def _output(self):
         # type: () -> pd.Series


### PR DESCRIPTION
This allows for forcing the write of an RSP even when it is not required. Typically a write only happens when we run across and RSP set. Now you can force a write to make the DRM in 3ML (so proper OGIP) format. Clears up some issues with GBM reps. 