### PR TITLE
installation instructions case segfault if astromodels is not upgraded

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ then:
 ```bash
 > pip install numpy scipy ipython
 > pip install git+https://github.com/giacomov/3ML.git 
-> pip install git+https://github.com/giacomov/astromodels.git
+> pip install git+https://github.com/giacomov/astromodels.git --upgrade
 ```
 
 In order to use the HAWC plugin, you will also need to install cthreeML (run this *after* setting up the HAWC environment):


### PR DESCRIPTION
coming back to the issue with segfault in astromodels. following the instructions exactly leads to a segfault. 
astromodels should be forcefully upgraded, else an incompatible version pip got as dependency for 3ML remains.