### PR TITLE
fixed scaling

### DIFF
--- a/threeML/plugins/SpectrumLike.py
+++ b/threeML/plugins/SpectrumLike.py
@@ -801,12 +801,17 @@ class SpectrumLike(PluginPrototype):
             # spectrum remain the same except for the rate and rate errors
 
             new_observation = self._observed_spectrum.clone(new_counts=randomized_source_counts,
-                                                            new_count_errors=randomized_source_count_err)
+                                                            new_count_errors=randomized_source_count_err,
+                                                            new_scale_factor=1.
+                                                            )
 
             if self._background_spectrum is not None:
 
                 new_background = self._background_spectrum.clone(new_counts=randomized_background_counts,
-                                                                 new_count_errors=randomized_background_count_err)
+                                                                 new_count_errors=randomized_background_count_err,
+                                                                 new_exposure=self._observed_spectrum.exposure, # because it was adjusted
+                                                                 new_scale_factor=1.
+                                                                 )
 
             else:
 

--- a/threeML/plugins/SpectrumLike.py
+++ b/threeML/plugins/SpectrumLike.py
@@ -800,6 +800,11 @@ class SpectrumLike(PluginPrototype):
             # member so as to build the appropriate spectrum type. All parameters of the current
             # spectrum remain the same except for the rate and rate errors
 
+            # the profile likelihood automatically adjust the background spectrum to the
+            # same exposure and scale as the observation
+            # therefore, we must  set the background simulation to have the exposure and scale
+            # of the observation
+
             new_observation = self._observed_spectrum.clone(new_counts=randomized_source_counts,
                                                             new_count_errors=randomized_source_count_err,
                                                             new_scale_factor=1.
@@ -810,7 +815,7 @@ class SpectrumLike(PluginPrototype):
                 new_background = self._background_spectrum.clone(new_counts=randomized_background_counts,
                                                                  new_count_errors=randomized_background_count_err,
                                                                  new_exposure=self._observed_spectrum.exposure, # because it was adjusted
-                                                                 new_scale_factor=1.
+                                                                 new_scale_factor=1. # because it was adjusted
                                                                  )
 
             else:

--- a/threeML/plugins/spectrum/binned_spectrum.py
+++ b/threeML/plugins/spectrum/binned_spectrum.py
@@ -701,6 +701,9 @@ class BinnedSpectrumWithDispersion(BinnedSpectrum):
         parameters the same
 
 
+        :param new_sys_errors:
+        :param new_exposure:
+        :param new_scale_factor:
         :param new_counts: new counts for the spectrum
         :param new_count_errors: new errors from the spectrum
         :return:

--- a/threeML/plugins/spectrum/binned_spectrum.py
+++ b/threeML/plugins/spectrum/binned_spectrum.py
@@ -384,7 +384,7 @@ class BinnedSpectrum(Histogram):
 
         return self._instrument
 
-    def clone(self, new_counts=None, new_count_errors=None, new_exposure=None):
+    def clone(self, new_counts=None, new_count_errors=None, new_exposure=None, new_scale_factor=None):
         """
         make a new spectrum with new counts and errors and all other
         parameters the same
@@ -402,13 +402,17 @@ class BinnedSpectrum(Histogram):
         if new_exposure is None:
             new_exposure = self.exposure
 
+        if new_scale_factor is None:
+
+            new_scale_factor = self._scale_factor
+
         return BinnedSpectrum(counts=new_counts,
                               ebounds=ChannelSet.from_list_of_edges(self.edges),
                               exposure=new_exposure,
                               count_errors=new_count_errors,
                               sys_errors=self._sys_errors,
                               quality=self._quality,
-                              scale_factor=self._scale_factor,
+                              scale_factor=new_scale_factor,
                               is_poisson=self._is_poisson,
                               mission=self._mission,
                               instrument=self._instrument)
@@ -691,7 +695,7 @@ class BinnedSpectrumWithDispersion(BinnedSpectrum):
                    scale_factor=1.,
                    is_poisson=is_poisson)
 
-    def clone(self, new_counts=None, new_count_errors=None, new_sys_errors=None, new_exposure=None):
+    def clone(self, new_counts=None, new_count_errors=None, new_sys_errors=None, new_exposure=None, new_scale_factor=None):
         """
         make a new spectrum with new counts and errors and all other
         parameters the same
@@ -712,13 +716,17 @@ class BinnedSpectrumWithDispersion(BinnedSpectrum):
         if new_exposure is None:
             new_exposure = self.exposure
 
+        if new_scale_factor is None:
+
+            new_scale_factor = self._scale_factor
+
         return BinnedSpectrumWithDispersion(counts=new_counts,
                                             exposure=new_exposure,
                                             response=self._rsp,
                                             count_errors=new_count_errors,
                                             sys_errors=new_sys_errors,
                                             quality=self._quality,
-                                            scale_factor=self._scale_factor,
+                                            scale_factor=new_scale_factor,
                                             is_poisson=self._is_poisson,
                                             mission=self._mission,
                                             instrument=self._instrument)

--- a/threeML/plugins/spectrum/pha_spectrum.py
+++ b/threeML/plugins/spectrum/pha_spectrum.py
@@ -784,7 +784,7 @@ p
 
         return self._grouping
 
-    def clone(self, new_counts=None, new_count_errors=None, ):
+    def clone(self, new_counts=None, new_count_errors=None, new_exposure=None ,new_scale_factor=None ):
         """
         make a new spectrum with new counts and errors and all other
         parameters the same
@@ -795,6 +795,10 @@ p
         :return: new pha spectrum
         """
 
+        if new_exposure is None:
+
+            new_exposure = self.exposure
+
         if new_counts is None:
             new_counts = self.counts
             new_count_errors = self.count_errors
@@ -803,9 +807,10 @@ p
         if new_count_errors is None:
             stat_err = None
 
+
         else:
 
-            stat_err = new_count_errors/self.exposure
+            stat_err = new_count_errors/new_exposure
 
         if self._tstart is None:
 
@@ -819,7 +824,7 @@ p
 
 
 
-            telapse = self.exposure
+            telapse = new_exposure
 
         else:
 
@@ -827,6 +832,10 @@ p
 
         # create a new PHAII instance
 
+
+        if new_scale_factor is None:
+
+            new_scale_factor = self.scale_factor
 
 
         pha = PHAII(instrument_name=self.instrument,
@@ -838,8 +847,8 @@ p
                     stat_err=stat_err,
                     quality=self.quality.to_ogip(),
                     grouping=self.grouping,
-                    exposure=self.exposure,
-                    backscale=self.scale_factor,
+                    exposure=new_exposure,
+                    backscale=new_scale_factor,
                     respfile=None,
                     ancrfile=None,
                     is_poisson=self.is_poisson)

--- a/threeML/plugins/spectrum/pha_spectrum.py
+++ b/threeML/plugins/spectrum/pha_spectrum.py
@@ -790,6 +790,9 @@ p
         parameters the same
 
 
+        :param new_exposure: the new exposure for the clone
+        :param new_scale_factor: the new scale factor for the clone
+
         :param new_counts: new counts for the spectrum
         :param new_count_errors: new errors from the spectrum
         :return: new pha spectrum
@@ -830,13 +833,14 @@ p
 
             telapse = self._tstop - tstart
 
-        # create a new PHAII instance
+
 
 
         if new_scale_factor is None:
 
             new_scale_factor = self.scale_factor
 
+        # create a new PHAII instance
 
         pha = PHAII(instrument_name=self.instrument,
                     telescope_name=self.mission,


### PR DESCRIPTION
When creating simulations, the simulated background was already scaled via the likeihood. However, the simulated spectra were keeping the original scaling which was modifying the background incorrectly. 

This fixes that. Now when a background is sampled, the scale factor and exposure are adjusted to 1 and the exposure of the observation respectively. 