### PR TITLE
HAWCLike::display for arbitrary locations

### DIFF
--- a/threeML/plugins/HAWCLike.py
+++ b/threeML/plugins/HAWCLike.py
@@ -433,7 +433,7 @@ class HAWCLike(PluginPrototype):
 
         for srcid in range(nsrc):
             ra, dec = self._model.get_point_source_position(srcid)
-            figs.append( self.display_point(ra, dec, radius, pulls) )
+            figs.append( self.display_residuals_at_position(ra, dec, radius, pulls) )
 
         return figs
 

--- a/threeML/plugins/HAWCLike.py
+++ b/threeML/plugins/HAWCLike.py
@@ -424,8 +424,7 @@ class HAWCLike(PluginPrototype):
 
         for srcid in range(nsrc):
             ra, dec = self._model.get_point_source_position(srcid)
-
-            figs.append( display_point(self, ra, dec, radius, pulls) )
+            figs.append( self.display_point(self, ra, dec, radius, pulls) )
 
         return figs
 

--- a/threeML/plugins/HAWCLike.py
+++ b/threeML/plugins/HAWCLike.py
@@ -422,7 +422,7 @@ class HAWCLike(PluginPrototype):
         Plot model&data/residuals vs HAWC analysis bins for all point sources in the model.
 
         :param radius: Radius of disk around each source over which model/data are evaluated. Default 0.5.
-        :param pulls: Plot pulls ( [excess-model]/model ) rather than fractional difference ( [excess-model]/model )
+        :param pulls: Plot pulls ( [excess-model]/uncertainty ) rather than fractional difference ( [excess-model]/model )
                       in lower panel (default: False).
         :return: list of figures (one plot per point source).
         """

--- a/threeML/plugins/HAWCLike.py
+++ b/threeML/plugins/HAWCLike.py
@@ -425,73 +425,77 @@ class HAWCLike(PluginPrototype):
         for srcid in range(nsrc):
             ra, dec = self._model.get_point_source_position(srcid)
 
-            model = np.array(self._theLikeHAWC.GetTopHatExpectedExcesses(ra, dec, radius))
-
-            signal = np.array(self._theLikeHAWC.GetTopHatExcesses(ra, dec, radius))
-
-            bkg = np.array(self._theLikeHAWC.GetTopHatBackgrounds(ra, dec, radius))
-
-            total = signal + bkg
-            
-            error = np.sqrt(total)
-
-            fig = plt.figure()
-
-            gs = gridspec.GridSpec(2, 1, height_ratios=[2, 1])
-            gs.update(hspace=0)
-
-            sub = plt.subplot(gs[0])
-
-            n_bins    = len(self._bin_list)
-            bin_index = np.arange(n_bins)
-
-            sub.errorbar(bin_index, total, yerr=error, capsize=0,
-                         color='black', label='Observation', fmt='.')
-
-            sub.plot(bin_index, model + bkg, label='Model + bkg')
-
-            plt.legend(bbox_to_anchor=(1.0, 1.0), loc="upper right",
-                       numpoints=1)
-
-            # Residuals
-
-            sub1 = plt.subplot(gs[1])
-
-            # Using model variance to account for low statistic
-
-            resid = (signal - model) / (error if pulls else model)
-
-            sub1.axhline(0, linestyle='--')
-
-            sub1.errorbar(
-                bin_index, resid,
-                yerr=np.zeros(error.shape) if pulls else error / model,
-                capsize=0, fmt='.'
-            )
-
-            x_limits = [-0.5, n_bins - 0.5]
-            sub.set_xlim(x_limits)
-
-            sub.set_yscale("log", nonposy='clip')
-
-            sub.set_ylabel("Counts per bin")
-
-            # sub1.set_xscale("log")
-
-            sub1.set_xlabel("Analysis bin")
-
-            sub1.set_ylabel(r"$\frac{{excess - "
-                            "mod.}}{{{}.}}$".format("err" if pulls else "mod"))
-
-            sub1.set_xlim(x_limits)
-
-            sub.set_xticks([])
-            sub1.set_xticks(bin_index)
-            sub1.set_xticklabels(self._bin_list)
-
-            figs.append(fig)
+            figs.append( display_point(self, ra, dec, radius, pulls) )
 
         return figs
+
+    def display_point(self, ra, dec, radius=0.5, pulls=False):
+
+        model = np.array(self._theLikeHAWC.GetTopHatExpectedExcesses(ra, dec, radius))
+
+        signal = np.array(self._theLikeHAWC.GetTopHatExcesses(ra, dec, radius))
+
+        bkg = np.array(self._theLikeHAWC.GetTopHatBackgrounds(ra, dec, radius))
+
+        total = signal + bkg
+            
+        error = np.sqrt(total)
+
+        fig = plt.figure()
+
+        gs = gridspec.GridSpec(2, 1, height_ratios=[2, 1])
+        gs.update(hspace=0)
+
+        sub = plt.subplot(gs[0])
+
+        n_bins    = len(self._bin_list)
+        bin_index = np.arange(n_bins)
+
+        sub.errorbar(bin_index, total, yerr=error, capsize=0,
+                         color='black', label='Observation', fmt='.')
+
+        sub.plot(bin_index, model + bkg, label='Model + bkg')
+
+        plt.legend(bbox_to_anchor=(1.0, 1.0), loc="upper right",
+                       numpoints=1)
+
+        # Residuals
+
+        sub1 = plt.subplot(gs[1])
+
+        # Using model variance to account for low statistic
+
+        resid = (signal - model) / (error if pulls else model)
+
+        sub1.axhline(0, linestyle='--')
+
+        sub1.errorbar(
+            bin_index, resid,
+            yerr=np.zeros(error.shape) if pulls else error / model,
+            capsize=0, fmt='.'
+        )
+
+        x_limits = [-0.5, n_bins - 0.5]
+        sub.set_xlim(x_limits)
+
+        sub.set_yscale("log", nonposy='clip')
+
+        sub.set_ylabel("Counts per bin")
+
+        # sub1.set_xscale("log")
+
+        sub1.set_xlabel("Analysis bin")
+
+        sub1.set_ylabel(r"$\frac{{excess - "
+                            "mod.}}{{{}.}}$".format("err" if pulls else "mod"))
+
+        sub1.set_xlim(x_limits)
+
+        sub.set_xticks([])
+        sub1.set_xticks(bin_index)
+        sub1.set_xticklabels(self._bin_list)
+
+        return fig
 
     def write_model_map(self, fileName, poisson=False):
 

--- a/threeML/plugins/HAWCLike.py
+++ b/threeML/plugins/HAWCLike.py
@@ -418,6 +418,15 @@ class HAWCLike(PluginPrototype):
 
     def display(self, radius=0.5, pulls=False):
 
+        """
+        Plot model&data/residuals vs HAWC analysis bins for all point sources in the model.
+
+        :param radius: Radius of disk around each source over which model/data are evaluated. Default 0.5.
+        :param pulls: Plot pulls ( [excess-model]/model ) rather than fractional difference ( [excess-model]/model )
+                      in lower panel (default: False).
+        :return: list of figures (one plot per point source).
+        """
+
         figs = []
 
         nsrc = self._model.get_number_of_point_sources()
@@ -428,7 +437,18 @@ class HAWCLike(PluginPrototype):
 
         return figs
 
-    def display_point(self, ra, dec, radius=0.5, pulls=False):
+    def display_residuals_at_position(self, ra, dec, radius=0.5, pulls=False):
+
+        """
+        Plot model&data/residuals vs HAWC analysis bins at arbitrary location.
+    
+        :param ra: R.A. of center of disk (in J2000) over which model/data are evaluated.
+        :param dec: Declination of center of disk.
+        :param radius: Radius of disk (in degrees). Default 0.5.
+        :param pulls: Plot pulls ( [excess-model]/uncertainty ) rather than fractional difference ( [excess-model]/model )
+                      in lower panel (default: False).
+        :return: matplotlib-type figure.
+        """
 
         model = np.array(self._theLikeHAWC.GetTopHatExpectedExcesses(ra, dec, radius))
 
@@ -495,6 +515,8 @@ class HAWCLike(PluginPrototype):
         sub1.set_xticklabels(self._bin_list)
 
         return fig
+
+
 
     def write_model_map(self, fileName, poisson=False):
 

--- a/threeML/plugins/HAWCLike.py
+++ b/threeML/plugins/HAWCLike.py
@@ -424,7 +424,7 @@ class HAWCLike(PluginPrototype):
 
         for srcid in range(nsrc):
             ra, dec = self._model.get_point_source_position(srcid)
-            figs.append( self.display_point(self, ra, dec, radius, pulls) )
+            figs.append( self.display_point(ra, dec, radius, pulls) )
 
         return figs
 

--- a/threeML/test/test_hawc.py
+++ b/threeML/test/test_hawc.py
@@ -232,3 +232,66 @@ def test_hawc_extended_source_fit():
 
     spectrum.display()
     shape.display()
+    
+    
+@skip_if_hawc_is_not_available
+def test_display_residuals():
+
+    # Ensure test environment is valid
+
+    assert is_plugin_available("HAWCLike"), "HAWCLike is not available!"
+
+    data_path = sanitize_filename(os.environ.get('HAWC_3ML_TEST_DATA_DIR'), abspath=True)
+
+    maptree = os.path.join(data_path, _maptree_name)
+    response = os.path.join(data_path, _response_name)
+
+    assert os.path.exists(maptree) and os.path.exists(response), "Data files do not exist at %s" % data_path
+
+    # The simulated source has this spectrum (credits for simulation: Colas Riviere):
+    # CutOffPowerLaw,3.15e-11,2.37,42.3
+    # at this position:
+    # 100,22
+
+    # Define the spectral and spatial models for the source
+    spectrum = Cutoff_powerlaw()
+    source = PointSource("TestSource", ra=100.0, dec=22.0, spectral_shape=spectrum)
+
+    spectrum.K = 3.15e-11 / (u.TeV * u.cm ** 2 * u.s)
+    spectrum.K.bounds = (1e-22, 1e-18)  # without units energies are in keV
+
+    spectrum.piv = 1 * u.TeV
+    spectrum.piv.fix = True
+
+    spectrum.index = -2.37
+    spectrum.index.bounds = (-4, -1)
+
+    spectrum.xc = 42.3 * u.TeV
+    spectrum.xc.bounds = (1 * u.TeV, 100 * u.TeV)
+
+    # Set up a likelihood model using the source.
+    # Then create a HAWCLike object using the model, the maptree, and detector
+    # response.
+    lm = Model(source)
+    llh = HAWCLike("HAWC", maptree, response)
+    llh.set_active_measurements(1, 9)
+
+    # Double check the free parameters
+    print("Likelihood model:\n")
+    print(lm)
+
+    # Set up the likelihood and run the fit
+    print("Performing likelihood fit...\n")
+    datalist = DataList(llh)
+    jl = JointLikelihood(lm, datalist, verbose=True)
+
+    jl.set_minimizer("ROOT")
+
+    parameter_frame, like = jl.fit(compute_covariance=False)
+
+    #Check the 'display' functions (plot model&data/residuals vs analysis bins)
+    llh.display(radius=0.5)
+    llh.display_residuals_at_position( source.position.ra.value, source.position.dec.value, radius = 0.5 )
+    
+    
+    


### PR DESCRIPTION
Hi, I've created a function to plot model&data/residuals vs HAWC analysis bins at arbitrary locations: `HAWCLike::display_point(Ra, Dec, radius, pulls)`. This is useful to test the spectral fit of extended sources. The name of the new function might not be optimal, I'm open for suggestions.