### PR TITLE
fix assign_to_source

### DIFF
--- a/threeML/plugins/XYLike.py
+++ b/threeML/plugins/XYLike.py
@@ -224,9 +224,9 @@ class XYLike(PluginPrototype):
         :return: none
         """
 
-        if self._likelihood_model is not None:
+        if self._likelihood_model is not None and source_name is not None:
 
-            assert self._source_name in self._likelihood_model.sources, "Source %s is not contained in " \
+            assert source_name in self._likelihood_model.sources, "Source %s is not contained in " \
                                                                         "the likelihood model" % source_name
 
         self._source_name = source_name


### PR DESCRIPTION
Hi! 

This is just a very small change to plugins/XYLike::assign_to_source, Line 227-229. The way line 229 currently is written makes it so I cannot assign a source to my XYLike object later on if I did not assign a source during construction. I don't think that's the intended behavior, maybe a typo?

The test should be 

```
        if self._likelihood_model is not None and source_name is not None:

            assert source_name in self._likelihood_model.sources, "Source %s is not contained in " \
"the likelihood model" % source_name

```
Instead of 

```
        if self._likelihood_model is not None:

            assert self._source_name in self._likelihood_model.sources, "Source %s is not contained in " \
"the likelihood model" % source_name

```

The change in line 227 would make it possible to 'un-assign' XYLike from any source. 

