### PR TITLE
allow spectrumlike from bins to understand tstart and stop

### DIFF
--- a/threeML/plugins/DispersionSpectrumLike.py
+++ b/threeML/plugins/DispersionSpectrumLike.py
@@ -13,7 +13,7 @@ __instrument_name = "General binned spectral data with energy dispersion"
 
 class DispersionSpectrumLike(SpectrumLike):
 
-    def __init__(self, name, observation, background=None, background_exposure=None,verbose=True):
+    def __init__(self, name, observation, background=None, background_exposure=None,verbose=True, tstart=None, tstop=None):
         """
         A plugin for generic spectral data with energy dispersion, accepts an observed binned spectrum,
         and a background binned spectrum or plugin with the background data.
@@ -49,7 +49,9 @@ class DispersionSpectrumLike(SpectrumLike):
                                                      observation=observation,
                                                      background=background,
                                                      background_exposure=background_exposure,
-                                                     verbose=verbose)
+                                                     verbose=verbose,
+                                                     tstart=tstart,
+                                                     tstop=tstop)
 
     def set_model(self, likelihoodModel):
         """

--- a/threeML/plugins/OGIP/pha.py
+++ b/threeML/plugins/OGIP/pha.py
@@ -57,6 +57,7 @@ class PHAWrite(object):
 
         self._pseudo_time = 0.
 
+
         self._spec_iterator = 1
 
     def write(self, outfile_name, overwrite=True, force_rsp_write=False):
@@ -103,6 +104,8 @@ class PHAWrite(object):
 
         # grab the ogip pha info
         pha_info = ogip.get_pha_files()
+
+
 
 
         first_channel = pha_info['rsp'].first_channel

--- a/threeML/plugins/SpectrumLike.py
+++ b/threeML/plugins/SpectrumLike.py
@@ -40,7 +40,7 @@ _known_noise_models = ['poisson', 'gaussian', 'ideal']
 
 
 class SpectrumLike(PluginPrototype):
-    def __init__(self, name, observation, background, verbose=True, background_exposure=None):
+    def __init__(self, name, observation, background, verbose=True, background_exposure=None, tstart=None, tstop=None):
         # type: (str, BinnedSpectrum, BinnedSpectrum, bool) -> None
         """
         A plugin for generic spectral data, accepts an observed binned spectrum,
@@ -335,8 +335,22 @@ class SpectrumLike(PluginPrototype):
         # This will be used to keep track of how many syntethic datasets have been generated
         self._n_synthetic_datasets = 0
 
-        self._tstart = None
-        self._tstop = None
+
+        if tstart is not None:
+
+            self._tstart = tstart
+
+        else:
+
+            self._tstart = observation.tstart
+
+        if tstop is not None:
+
+            self._tstop = tstop
+
+        else:
+
+            self._tstop = observation.tstop
 
         # This is so far not a simulated data set
         self._simulation_storage = None

--- a/threeML/test/test_ogip.py
+++ b/threeML/test/test_ogip.py
@@ -58,8 +58,8 @@ def test_loading_a_generic_pha_file():
         assert ogip.name == 'test_ogip'
         assert ogip.n_data_points == sum(ogip._mask)
         assert sum(ogip._mask) == ogip.n_data_points
-        assert ogip.tstart is None
-        assert ogip.tstop is None
+        assert ogip.tstart == 0.
+        assert ogip.tstop == 9.95012
         assert 'cons_test_ogip' in ogip.nuisance_parameters
         assert ogip.nuisance_parameters['cons_test_ogip'].fix == True
         assert ogip.nuisance_parameters['cons_test_ogip'].free == False
@@ -348,8 +348,8 @@ def test_simulating_data_sets():
 
         assert new_ogip.n_data_points == sum(new_ogip._mask)
         assert sum(new_ogip._mask) == new_ogip.n_data_points
-        assert new_ogip.tstart is None
-        assert new_ogip.tstop is None
+        assert new_ogip.tstart == 0.
+
         assert 'cons_sim' in new_ogip.nuisance_parameters
         assert new_ogip.nuisance_parameters['cons_sim'].fix == True
         assert new_ogip.nuisance_parameters['cons_sim'].free == False

--- a/threeML/utils/data_builders/time_series_builder.py
+++ b/threeML/utils/data_builders/time_series_builder.py
@@ -477,14 +477,19 @@ class TimeSeriesBuilder(object):
                 return SpectrumLike(name=self._name,
                                     observation=self._observed_spectrum,
                                     background=self._background_spectrum,
-                                    verbose=self._verbose)
+                                    verbose=self._verbose,
+                                    tstart=self._tstart,
+                                    tstop=self._tstop)
 
             else:
 
                 return DispersionSpectrumLike(name=self._name,
                                               observation=self._observed_spectrum,
                                               background=self._background_spectrum,
-                                              verbose=self._verbose)
+                                              verbose=self._verbose,
+                                              tstart = self._tstart,
+                                              tstop = self._tstop
+                                              )
 
 
         else:
@@ -536,14 +541,18 @@ class TimeSeriesBuilder(object):
                             sl = SpectrumLike(name="%s%s%d" % (self._name, interval_name, i),
                                               observation=self._observed_spectrum,
                                               background=self._background_spectrum,
-                                              verbose=self._verbose)
+                                              verbose=self._verbose,
+                                              tstart=self._tstart,
+                                              tstop=self._tstop)
 
                         else:
 
                             sl = DispersionSpectrumLike(name="%s%s%d" % (self._name, interval_name, i),
                                                         observation=self._observed_spectrum,
                                                         background=self._background_spectrum,
-                                                        verbose=self._verbose)
+                                                        verbose=self._verbose,
+                                                        tstart=self._tstart,
+                                                        tstop=self._tstop)
 
                         list_of_speclikes.append(sl)
 


### PR DESCRIPTION
The writing of PHAs and creation of plugins from time series was not properly keeping track of time. It has been fixed