### PR TITLE
fix negative rates in plot

### DIFF
--- a/threeML/plugins/SpectrumLike.py
+++ b/threeML/plugins/SpectrumLike.py
@@ -2656,6 +2656,14 @@ class SpectrumLike(PluginPrototype):
 
             else:
 
+                # negative src rates cause the energy mean to
+                # go outside of the bounds. So we fix negative rates to
+                # zero when computing the mean 
+
+                idx_negative = r<0.
+
+                r[idx_negative] =0.
+
                 # Do the weighted average of the mean energies
                 weights = r / np.sum(r)
 


### PR DESCRIPTION
This fixes #259 

The issue was that negative source rates were causing the weighted average energy bin centers to fall outside of the actual energy bins. I have instead made it so that negative rates do not contribute to the average by setting their weights to zero explicitly. 