### PR TITLE
fixed non-updating intervals

### DIFF
--- a/threeML/utils/time_series/time_series.py
+++ b/threeML/utils/time_series/time_series.py
@@ -326,42 +326,45 @@ class TimeSeries(object):
 
         for i,time_interval in enumerate(poly_intervals):
 
-            keep_interval = True
 
 
             t1 = time_interval.start_time
             t2 = time_interval.stop_time
 
-            if t1 < self._start_time:
-
-                custom_warnings.warn(
-                    "The time interval %f-%f started before the first arrival time (%f), so we are changing the intervals to %f-%f" % (
-                    t1, t2, self._start_time, self._start_time, t2))
-
-                t1 = self._start_time# + 1
-
-
-
-
-
-            if t2 > self._stop_time:
-
-                custom_warnings.warn(
-                    "The time interval %f-%f ended after the last arrival time (%f), so we are changing the intervals to %f-%f" % (
-                        t1, t2, self._stop_time, t1, self._stop_time))
-
-                t2 = self._stop_time# - 1.
-
-
-
-            if  (self._stop_time <= t1) or (t2 <= self._start_time):
+            if (self._stop_time <= t1) or (t2 <= self._start_time):
                 custom_warnings.warn(
                     "The time interval %f-%f is out side of the arrival times and will be dropped" % (
                         t1, t2))
 
-                keep_interval = False
+              
 
-            if keep_interval:
+
+            else:
+
+                if t1 < self._start_time:
+
+                    custom_warnings.warn(
+                        "The time interval %f-%f started before the first arrival time (%f), so we are changing the intervals to %f-%f" % (
+                        t1, t2, self._start_time, self._start_time, t2))
+
+                    t1 = self._start_time# + 1
+
+
+
+
+
+                if t2 > self._stop_time:
+
+                    custom_warnings.warn(
+                        "The time interval %f-%f ended after the last arrival time (%f), so we are changing the intervals to %f-%f" % (
+                            t1, t2, self._stop_time, t1, self._stop_time))
+
+                    t2 = self._stop_time# - 1.
+
+
+
+
+
 
                 new_intervals.append('%f-%f' %(t1,t2))
 


### PR DESCRIPTION
Fits to time series backgrounds were not properly updating the intervals when the user selected time intervals that were outside of the data ranges. This caused time bins with ZERO counts to be included in the fit. This would have resulted in a stall during the fit or incorrect fits. This has now been fixed. 