### PR TITLE
Fix radial profiles

### DIFF
--- a/threeML/plugins/HAWCLike.py
+++ b/threeML/plugins/HAWCLike.py
@@ -645,18 +645,22 @@ class HAWCLike(PluginPrototype):
         # Use GetTopHatAreas to get the area of all pixels in a given circle.
         # The area of each ring is then given by the differnence between two subseqent circle areas.
         area = np.array( [self._theLikeHAWC.GetTopHatAreas(ra, dec, r+0.5*delta_r) for r in radii ] )
-        area[1:] -= area[:-1] #convert to ring area 
+        temp = area[1:] - area[:-1] 
+        area[1:] = temp #convert to ring area 
         area = area*(np.pi/180.)**2 #convert to sr
         
         model = np.array( [self._theLikeHAWC.GetTopHatExpectedExcesses(ra, dec, r+0.5*delta_r) for r in radii ] )
-        model[1:] -= model[:-1] #convert 'top hat' excesses into 'ring' excesses.
+        temp = model[1:] - model[:-1] #convert 'top hat' excesses into 'ring' excesses.
+        model[1:] = temp
 
         signal = np.array( [self._theLikeHAWC.GetTopHatExcesses(ra, dec, r+0.5*delta_r) for r in radii ] )
-        signal[1:] -= signal[:-1]
+        temp = signal[1:] - signal[:-1]
+        signal[1:] = temp
 
         bkg = np.array( [self._theLikeHAWC.GetTopHatBackgrounds(ra, dec, r+0.5*delta_r) for r in radii ])
-        bkg[1:] -= bkg[:-1]
-
+        temp = bkg[1:] - bkg[:-1]
+        bkg[1:] = temp
+        
         counts = signal + bkg
 
         if model_to_subtract is not None:
@@ -665,7 +669,8 @@ class HAWCLike(PluginPrototype):
           self._fill_model_cache()
           self.calc_TS()
           model_subtract = np.array( [self._theLikeHAWC.GetTopHatExpectedExcesses(ra, dec, r+0.5*delta_r) for r in radii ] )
-          model_subtract[1:] -= model_subtract[:-1]
+          temp = model_subtract[1:] - model_subtract[:-1]
+          model_subtract[1:] = temp
           signal -= model_subtract
           self.set_model(this_model)
           self._fill_model_cache()

--- a/threeML/test/test_hawc.py
+++ b/threeML/test/test_hawc.py
@@ -360,7 +360,6 @@ def test_null_hyp_prob(hawc_point_source_fitted_joint_like):
 
 
 @skip_if_hawc_is_not_available
-@pytest.mark.xfail
 def test_radial_profile(hawc_point_source_fitted_joint_like):
     # Ensure test environment is valid
 
@@ -405,23 +404,6 @@ def test_radial_profile(hawc_point_source_fitted_joint_like):
         assert is_within_tolerance(excess_data[i], correct_data[i])
         assert is_within_tolerance(excess_error[i], correct_error[i])
 
-    radii, excess_model, excess_data, excess_error, list_of_bin_names = llh.get_radial_profile(source.position.ra.value,
-                                                                                               source.position.dec.value,
-                                                                                               bins_to_use, max_radius,
-                                                                                               n_bins, lm)
-
-    assert len(radii) == n_bins
-    assert len(excess_model) == n_bins
-    assert len(excess_data) == n_bins
-    assert len(excess_error) == n_bins
-
-    assert list_of_bin_names == correct_bins
-
-    for i in range(0, n_bins):
-        assert is_within_tolerance(radii[i], correct_radii[i])
-        assert is_within_tolerance(excess_model[i], correct_model[i])
-        assert is_within_tolerance(excess_data[i], subtracted_data[i])
-        assert is_within_tolerance(excess_error[i], correct_error[i])
 
 
 @skip_if_hawc_is_not_available


### PR DESCRIPTION
Statements like 

`area[1:] -= area[:-1]`  

are not a good idea because apparently the order in which the subtraction/assignments are executed changed between numpy versions.
   

