### PR TITLE
Fix error when reading in fit results with one free parameter

### DIFF
--- a/threeML/analysis_results.py
+++ b/threeML/analysis_results.py
@@ -116,7 +116,7 @@ def _load_one_results(fits_extension):
 
         # Get covariance matrix
 
-        covariance_matrix = fits_extension.data.field("COVARIANCE").T
+        covariance_matrix = np.atleast_2d(fits_extension.data.field("COVARIANCE").T)
 
         # Instance and return
 


### PR DESCRIPTION
Hi!

This pull request fixes an error when reading in fit results with only one free parameter from a fits file:

```
  File "/Users/hfleisch/software/miniconda2/envs/fermipy_hawc/lib/python2.7/site-packages/threeML/analysis_results.py", line 73, in load_analysis_results
    return _load_one_results(f['ANALYSIS_RESULTS', 1])
  File "/Users/hfleisch/software/miniconda2/envs/fermipy_hawc/lib/python2.7/site-packages/threeML/analysis_results.py", line 123, in _load_one_results
    return MLEResults(optimized_model, covariance_matrix, statistic_values, statistical_measures=measure_values)
  File "/Users/hfleisch/software/miniconda2/envs/fermipy_hawc/lib/python2.7/site-packages/threeML/analysis_results.py", line 1158, in __init__
    expected_shape)
AssertionError: Covariance matrix has wrong shape. Got (1,), should be (1, 1)
```

Here's some example code to reproduce the error (works with the fix).

```
import numpy as np
import warnings

with warnings.catch_warnings():

    warnings.simplefilter("ignore")
    
    from threeML import *

fluxUnit = 1. / (u.TeV * u.cm**2 * u.s)

spectrum=Powerlaw()
source = PointSource( "tst", ra=100 , dec=20, spectral_shape=spectrum)
model = Model(source)

spectrum.piv = 7*u.TeV      
spectrum.index = -2.3
spectrum.K = 1e-15*fluxUnit  

spectrum.piv.fix = True

#two free parameters (one with units): works
spectrum.index.fix = False
spectrum.K.fix = False
cov_matrix = np.diag([0.001]*2)
results = analysis_results.MLEResults(model, cov_matrix, {})  
results.write_to("test1.fits")
results_reloaded = load_analysis_results( "test1.fits" )
print results_reloaded.get_data_frame()


#one free parameter with units: crashes
spectrum.index.fix = True
spectrum.K.fix = False
cov_matrix = np.diag([0.001]*1)
results = analysis_results.MLEResults(model, cov_matrix, {})  
results.write_to("test2.fits")
results_reloaded = load_analysis_results( "test2.fits" )
print results_reloaded.get_data_frame()


#one free parameter without units: crashes
spectrum.index.fix = False
spectrum.K.fix = True
cov_matrix = np.diag([0.001]*1)
results = analysis_results.MLEResults(model, cov_matrix, {})  
results.write_to("test3.fits")
results_reloaded = load_analysis_results( "test3.fits" )
print results_reloaded.get_data_frame()


```