### PR TITLE
Small fix in XYLike::plot()

### DIFF
--- a/threeML/plugins/XYLike.py
+++ b/threeML/plugins/XYLike.py
@@ -31,7 +31,7 @@ class XYLike(PluginPrototype):
 
         # If there are specified errors, use those (assume Gaussian statistic)
         # otherwise make sure that the user specified poisson_error = True and use
-        # Posson statistic
+        # Poisson statistic
 
         if yerr is not None:
 

--- a/threeML/plugins/XYLike.py
+++ b/threeML/plugins/XYLike.py
@@ -31,7 +31,7 @@ class XYLike(PluginPrototype):
 
         # If there are specified errors, use those (assume Gaussian statistic)
         # otherwise make sure that the user specified poisson_error = True and use
-        # Poisson statistic
+        # Posson statistic
 
         if yerr is not None:
 
@@ -403,7 +403,7 @@ class XYLike(PluginPrototype):
 
         if self._likelihood_model is not None:
 
-            flux = self._likelihood_model.get_total_flux(self.x)
+            flux = self._get_total_expectation()
 
             sub.plot(self.x, flux, '--', label='model')
 


### PR DESCRIPTION
Hi!

I think in XYLike::plot() we should use `self._get_total_expectation()` to get the model spectrum rather than `self._likelihood_model.get_total_flux(self.x)`. The latter always returns the sum of the fluxes of all point sources, while the former correctly takes into account whether or not the XYLike plugin has been assigned to a particular source or to the sum of all (point) sources.