### PR TITLE
Mpi mn

### DIFF
--- a/threeML/bayesian/bayesian_analysis.py
+++ b/threeML/bayesian/bayesian_analysis.py
@@ -430,11 +430,15 @@ class BayesianAnalysis(object):
 
             if rank !=0:
 
+                # let these guys take a break
                 time.sleep(5)
+
+                # these engines do not need to read
                 process_fit = False
 
             else:
 
+                # wait for a moment to allow it all to turn off
                 time.sleep(5)
 
                 process_fit = True


### PR DESCRIPTION
If a user is running multinest with MPI, the chains were being analyzed on each engine as they finished. This caused the statistics, and distributions to vary and only the slowest chains information was used. 

Now, chains are analyzed after everything is completed.