### PR TITLE
Call calc_TS every time it might be needed just to be sure

### DIFF
--- a/threeML/plugins/HAWCLike.py
+++ b/threeML/plugins/HAWCLike.py
@@ -328,6 +328,7 @@ class HAWCLike(PluginPrototype):
 
         self._energies = np.array(self._theLikeHAWC.GetEnergies(False)) * 1000.0
         
+        #make sure the model maps etc. get filled
         self.get_log_like()
 
     def _CommonNormCallback(self, commonNorm_parameter):

--- a/threeML/plugins/HAWCLike.py
+++ b/threeML/plugins/HAWCLike.py
@@ -438,7 +438,10 @@ class HAWCLike(PluginPrototype):
         :param dec: Declination in degrees of top-hat center.
         :param radius: List of top-hat radii in degrees (one per analysis bin).
         """
-
+        
+        #make sure the model maps are filled correctly.
+        self.calc_TS()
+        
         return self._theLikeHAWC.calcPValue(ra, dec, radius)
 
     def write_map(self, file_name):
@@ -450,6 +453,9 @@ class HAWCLike(PluginPrototype):
         :return: None
         """
 
+        #make sure the model maps are filled correctly.
+        self.calc_TS()
+        
         self._theLikeHAWC.WriteMap(file_name)
 
     def get_nuisance_parameters(self):
@@ -505,6 +511,9 @@ class HAWCLike(PluginPrototype):
         :return: matplotlib-type figure.
         """
 
+        #make sure the model maps are filled correctly.
+        self.calc_TS()
+        
         n_bins = len(self._bin_list)
         bin_index = np.arange(n_bins)
 
@@ -626,9 +635,9 @@ class HAWCLike(PluginPrototype):
         :return: np arrays with the radii, model profile, data profile, data uncertainty, list of analysis bins used.
         """
 
-        self._fill_model_cache()
+        #make sure the model maps are filled correctly.
         self.calc_TS()
-
+        
         #default is to use all active bins
         if bin_list is None:
             bin_list = self._bin_list
@@ -764,14 +773,15 @@ class HAWCLike(PluginPrototype):
 
     def write_model_map(self, fileName, poisson=False):
 
-        # This is to make sure we have computed the sources (otherwise the following method WriteModelMap will fail
-        self._fill_model_cache()
-
+        #make sure the model maps are filled correctly.
+        self.calc_TS()
+        
         self._theLikeHAWC.WriteModelMap(fileName, poisson)
 
     def write_residual_map(self, fileName):
  
-        self._fill_model_cache()
-
+        #make sure the model maps are filled correctly.
+        self.calc_TS()
+        
         self._theLikeHAWC.WriteResidualMap(fileName)
 

--- a/threeML/plugins/HAWCLike.py
+++ b/threeML/plugins/HAWCLike.py
@@ -327,6 +327,8 @@ class HAWCLike(PluginPrototype):
         # (note that the output is in MeV, while we need keV)
 
         self._energies = np.array(self._theLikeHAWC.GetEnergies(False)) * 1000.0
+        
+        self.get_log_like()
 
     def _CommonNormCallback(self, commonNorm_parameter):
 
@@ -439,9 +441,6 @@ class HAWCLike(PluginPrototype):
         :param radius: List of top-hat radii in degrees (one per analysis bin).
         """
         
-        #make sure the model maps are filled correctly.
-        self.calc_TS()
-        
         return self._theLikeHAWC.calcPValue(ra, dec, radius)
 
     def write_map(self, file_name):
@@ -452,9 +451,6 @@ class HAWCLike(PluginPrototype):
         :param file_name: name for the output map
         :return: None
         """
-
-        #make sure the model maps are filled correctly.
-        self.calc_TS()
         
         self._theLikeHAWC.WriteMap(file_name)
 
@@ -510,9 +506,6 @@ class HAWCLike(PluginPrototype):
                       in lower panel (default: False).
         :return: matplotlib-type figure.
         """
-
-        #make sure the model maps are filled correctly.
-        self.calc_TS()
         
         n_bins = len(self._bin_list)
         bin_index = np.arange(n_bins)
@@ -634,10 +627,7 @@ class HAWCLike(PluginPrototype):
         
         :return: np arrays with the radii, model profile, data profile, data uncertainty, list of analysis bins used.
         """
-
-        #make sure the model maps are filled correctly.
-        self.calc_TS()
-        
+                
         #default is to use all active bins
         if bin_list is None:
             bin_list = self._bin_list
@@ -676,8 +666,6 @@ class HAWCLike(PluginPrototype):
         if model_to_subtract is not None:
             this_model = deepcopy(self._model)
             self.set_model( model_to_subtract )
-            self._fill_model_cache()
-            self.calc_TS()
             model_subtract = np.array( [self._theLikeHAWC.GetTopHatExpectedExcesses(ra, dec, r+0.5*delta_r) for r in radii ] )
             temp = model_subtract[1:] - model_subtract[:-1]
             model_subtract[1:] = temp
@@ -685,8 +673,6 @@ class HAWCLike(PluginPrototype):
             if subtract_model_from_model:
                 model -=  model_subtract
             self.set_model(this_model)
-            self._fill_model_cache()
-            self.calc_TS()
            
         # weights are calculated as expected number of gamma-rays / number of background counts.
         # here, use max_radius to evaluate the number of gamma-rays/bkg counts.
@@ -772,16 +758,10 @@ class HAWCLike(PluginPrototype):
         return fig
 
     def write_model_map(self, fileName, poisson=False):
-
-        #make sure the model maps are filled correctly.
-        self.calc_TS()
         
         self._theLikeHAWC.WriteModelMap(fileName, poisson)
 
     def write_residual_map(self, fileName):
- 
-        #make sure the model maps are filled correctly.
-        self.calc_TS()
         
         self._theLikeHAWC.WriteResidualMap(fileName)
 


### PR DESCRIPTION
I noticed that e.g. the residual plots  with the `HAWCLike` plugin would fail after calling the new `compute_TS` function, presumably because the HAWC model cache  wasn't filled correctly. This can be fixed by calling `calc_TS` or similar. Rather than relying on the user to call `calc_TS` before making residual plots, I just added calls to `calc_TS` to every function where it might be needed, just to be safe.