### PR TITLE
uncertainty_formatter constistency

### DIFF
--- a/threeML/io/uncertainty_formatter.py
+++ b/threeML/io/uncertainty_formatter.py
@@ -140,15 +140,15 @@ def uncertainty_formatter(value, low_bound, hi_bound):
 
         if expon == 0:
 
-            return "%.3f %s" % (float(num), repr1)
+            return "%s %s" % (num, repr1)
 
         elif expon == 1:
 
-            return "(%.3f %s) x 10" % (float(num), repr1)
+            return "(%s %s) x 10" % (num, repr1)
 
         else:
 
-            return "(%.3f %s) x 10^%s" % (float(num), repr1, expon)
+            return "(%s %s) x 10^%s" % (num, repr1, expon)
 
 
 def _sign(number):


### PR DESCRIPTION
More consistent formatting for symmetric and asymetric errors. Before this commit, the output of
```python
import threeML.io.uncertainty_formatter as uf

epsilon = 1e-6
for value, error_m, error_p in [(1, epsilon, epsilon), (1, epsilon, 2*epsilon)]:
    low_bound, hi_bound = (value - error_m, value + error_p)
    print uf.uncertainty_formatter(value, low_bound, hi_bound)
```
was
```
1.000 +/- 0.0000010
1.0000000 -0.0000010 +0.0000020
```
where we don't have enough significant digits for the value in the symmetric case.
After the commit, the output is
```
1.0000000 +/- 0.0000010
1.0000000 -0.0000010 +0.0000020
```
which is more consistent.