### PR TITLE
Add cstat bkg to timeseries

### DIFF
--- a/threeML/test/test_time_series.py
+++ b/threeML/test/test_time_series.py
@@ -126,6 +126,14 @@ def test_read_gbm_cspec():
 
         assert isinstance(speclike, DispersionSpectrumLike)
 
+        assert not speclike.background_spectrum.is_poisson
+
+        speclike = nai3.to_spectrumlike(extract_measured_background=True)
+
+        assert isinstance(speclike, DispersionSpectrumLike)
+
+        assert speclike.background_spectrum.is_poisson
+
         nai3.write_pha_from_binner('test_from_nai3', start=0, stop=2, overwrite=True)
 
 
@@ -141,9 +149,23 @@ def test_read_gbm_tte():
         nai3.set_active_time_interval('0-1')
         nai3.set_background_interval('-20--10', '100-200')
 
+
+
+
         speclike = nai3.to_spectrumlike()
 
         assert isinstance(speclike, DispersionSpectrumLike)
+
+
+        assert not speclike.background_spectrum.is_poisson
+
+        speclike = nai3.to_spectrumlike(extract_measured_background=True)
+
+        assert isinstance(speclike, DispersionSpectrumLike)
+
+        assert speclike.background_spectrum.is_poisson
+
+
 
         # test binning
 

--- a/threeML/test/test_time_series.py
+++ b/threeML/test/test_time_series.py
@@ -122,6 +122,7 @@ def test_read_gbm_cspec():
         nai3.set_active_time_interval('0-1')
         nai3.set_background_interval('-200--10', '100-200')
 
+
         speclike = nai3.to_spectrumlike()
 
         assert isinstance(speclike, DispersionSpectrumLike)

--- a/threeML/utils/data_builders/time_series_builder.py
+++ b/threeML/utils/data_builders/time_series_builder.py
@@ -534,7 +534,8 @@ class TimeSeriesBuilder(object):
         :param from_bins: choose to create plugins from the time bins
         :param start: optional start time of the bins
         :param stop: optional stop time of the bins
-
+        :param extract_measured_background: Use the selected background rather than a polynomial fit to the background
+        :param interval_name: the name of the interval
         :return: SpectrumLike plugin(s)
         """
 

--- a/threeML/utils/data_builders/time_series_builder.py
+++ b/threeML/utils/data_builders/time_series_builder.py
@@ -83,6 +83,7 @@ class TimeSeriesBuilder(object):
         self._active_interval = None
         self._observed_spectrum = None
         self._background_spectrum = None
+        self._measured_background_spectrum = None
 
         self._time_series.poly_order = poly_order
 
@@ -97,18 +98,6 @@ class TimeSeriesBuilder(object):
 
                 if verbose:
                     print('Successfully restored fit from %s'%restore_poly_fit)
-
-                # In theory this will automatically get the poly counts if a
-                # time interval already exists
-                #
-                # if self._response is None:
-                #
-                #     self._background_spectrum = BinnedSpectrum.from_time_series(self._time_series, use_poly=True)
-                #
-                # else:
-                #     self._background_spectrum = BinnedSpectrumWithDispersion.from_time_series(self._time_series,
-                #                                                                               self._response,
-                #                                                                               use_poly=True)
 
 
             else:
@@ -182,12 +171,23 @@ class TimeSeriesBuilder(object):
 
             if self._response is None:
 
-                self._background_spectrum = BinnedSpectrum.from_time_series(self._time_series, use_poly=True)
+                raise NotImplementedError('We have not put this in yet')
+
+                #self._background_spectrum = BinnedSpectrum.from_time_series(self._time_series, use_poly=True)
 
             else:
 
                 self._background_spectrum = BinnedSpectrumWithDispersion.from_time_series(self._time_series,
-                                                                                          self._response, use_poly=True)
+                                                                                          self._response,
+                                                                                          use_poly=True,
+                                                                                          extract=False
+                                                                                          )
+
+                self._measured_background_spectrum = BinnedSpectrumWithDispersion.from_time_series(self._time_series,
+                                                                                                   self._response,
+                                                                                                   use_poly=False,
+                                                                                                   extract=True,
+                                                                                                   )
 
         self._tstart = self._time_series.time_intervals.absolute_start_time
         self._tstop = self._time_series.time_intervals.absolute_stop_time
@@ -224,16 +224,36 @@ class TimeSeriesBuilder(object):
 
             if self._response is None:
 
-                self._background_spectrum = BinnedSpectrum.from_time_series(self._time_series, use_poly=True)
+                raise NotImplementedError('Not yet implemented for non-dispersed measurements')
+                #
+                # self._background_spectrum = BinnedSpectrum.from_time_series(self._time_series,
+                #                                                             use_poly=True,
+                #                                                             extract = False
+                #
+                #
+                #                                                             )
+                #
+                # self._background_spectrum = BinnedSpectrum.from_time_series(self._time_series,
+                #                                                             use_poly=False,
+                #                                                             extract=True)
 
             else:
 
                 # we do not need to worry about the interval of the response if it is a set. only the ebounds are extracted here
 
-                self._background_spectrum = BinnedSpectrumWithDispersion.from_time_series(self._time_series, self._response,
-                                                                                          use_poly=True)
+                self._background_spectrum = BinnedSpectrumWithDispersion.from_time_series(self._time_series,
+                                                                                          self._response,
+                                                                                          use_poly=True,
+                                                                                          extract=False
+                                                                                          )
 
-    def write_pha_from_binner(self, file_name, start=None, stop=None, overwrite=False, force_rsp_write=False):
+                self._measured_background_spectrum = BinnedSpectrumWithDispersion.from_time_series(self._time_series,
+                                                                                                   self._response,
+                                                                                                   use_poly=False,
+                                                                                                   extract=True,
+                                                                                                   )
+
+    def write_pha_from_binner(self, file_name, start=None, stop=None, overwrite=False, force_rsp_write=False, extract_measured_background=False):
         """
         Write PHA fits files from the selected bins. If writing from an event list, the
         bins are from create_time_bins. If using a pre-time binned time series, the bins are those
@@ -244,6 +264,7 @@ class TimeSeriesBuilder(object):
         :param stop: optional stop time of the bins
         :param overwrite: if the fits files should be overwritten
         :param force_rsp_write: force the writing of RSPs
+        :param extract_measured_background: Use the selected background rather than a polynomial fit to the background
         :return: None
         """
 
@@ -251,7 +272,8 @@ class TimeSeriesBuilder(object):
 
         ogip_list = [OGIPLike.from_general_dispersion_spectrum(sl) for sl in self.to_spectrumlike(from_bins=True,
                                                                                                   start=start,
-                                                                                                  stop=stop)]
+                                                                                                  stop=stop,
+                                                                                                  extract_measured_background=extract_measured_background)]
 
         # write out the PHAII file
 
@@ -502,7 +524,7 @@ class TimeSeriesBuilder(object):
             print('Created %d bins via %s'% (len(self._time_series.bins), method))
 
 
-    def to_spectrumlike(self, from_bins=False, start=None, stop=None, interval_name='_interval'):
+    def to_spectrumlike(self, from_bins=False, start=None, stop=None, interval_name='_interval', extract_measured_background=False):
         """
         Create plugin(s) from either the current active selection or the time bins.
         If creating from an event list, the
@@ -516,21 +538,36 @@ class TimeSeriesBuilder(object):
         :return: SpectrumLike plugin(s)
         """
 
+
+        # we can use either the modeled or the measured background. In theory, all the information
+        # in the background spectrum should propagate to the likelihood
+
+        if extract_measured_background:
+
+            this_background_spectrum = self._measured_background_spectrum
+
+        else:
+
+
+            this_background_spectrum = self._background_spectrum
+
         # this is for a single interval
+
+
         if not from_bins:
 
             assert self._observed_spectrum is not None, 'Must have selected an active time interval'
 
-            if self._background_spectrum is None:
+            if this_background_spectrum is None:
 
-                custom_warnings.warn('No bakckground selection has been made. This plugin will contain no background!')
+                custom_warnings.warn('No background selection has been made. This plugin will contain no background!')
 
 
             if self._response is None:
 
                 return SpectrumLike(name=self._name,
                                     observation=self._observed_spectrum,
-                                    background=self._background_spectrum,
+                                    background=this_background_spectrum,
                                     verbose=self._verbose,
                                     tstart=self._tstart,
                                     tstop=self._tstop)
@@ -539,7 +576,7 @@ class TimeSeriesBuilder(object):
 
                 return DispersionSpectrumLike(name=self._name,
                                               observation=self._observed_spectrum,
-                                              background=self._background_spectrum,
+                                              background=this_background_spectrum,
                                               verbose=self._verbose,
                                               tstart = self._tstart,
                                               tstop = self._tstop
@@ -588,7 +625,7 @@ class TimeSeriesBuilder(object):
 
                     self.set_active_time_interval(interval.to_string())
 
-                    if self._background_spectrum is None:
+                    if this_background_spectrum is None:
                         custom_warnings.warn(
                             'No bakckground selection has been made. This plugin will contain no background!')
 
@@ -598,7 +635,7 @@ class TimeSeriesBuilder(object):
 
                             sl = SpectrumLike(name="%s%s%d" % (self._name, interval_name, i),
                                               observation=self._observed_spectrum,
-                                              background=self._background_spectrum,
+                                              background=this_background_spectrum,
                                               verbose=self._verbose,
                                               tstart=self._tstart,
                                               tstop=self._tstop)
@@ -607,7 +644,7 @@ class TimeSeriesBuilder(object):
 
                             sl = DispersionSpectrumLike(name="%s%s%d" % (self._name, interval_name, i),
                                                         observation=self._observed_spectrum,
-                                                        background=self._background_spectrum,
+                                                        background=this_background_spectrum,
                                                         verbose=self._verbose,
                                                         tstart=self._tstart,
                                                         tstop=self._tstop)

--- a/threeML/utils/spectrum/binned_spectrum.py
+++ b/threeML/utils/spectrum/binned_spectrum.py
@@ -522,7 +522,7 @@ class BinnedSpectrum(Histogram):
         return pd.DataFrame(out_dict)
     
     @classmethod
-    def from_time_series(cls, time_series, use_poly=False):
+    def from_time_series(cls, time_series, use_poly=False, from_model=False):
         """
 
         :param time_series:
@@ -666,7 +666,7 @@ class BinnedSpectrumWithDispersion(BinnedSpectrum):
         return self._rsp
 
     @classmethod
-    def from_time_series(cls, time_series, response, use_poly=False):
+    def from_time_series(cls, time_series, response, use_poly=False, extract=False):
         """
 
         :param time_series:
@@ -674,13 +674,18 @@ class BinnedSpectrumWithDispersion(BinnedSpectrum):
         :return:
         """
 
+        assert not (use_poly and extract), 'cannot extract background counts and use the poly'
 
-        pha_information = time_series.get_information_dict(use_poly)
+        pha_information = time_series.get_information_dict(use_poly, extract)
 
         is_poisson = True
 
         if use_poly:
             is_poisson = False
+
+
+
+
 
         return cls(instrument=pha_information['instrument'],
                    mission=pha_information['telescope'],

--- a/threeML/utils/time_series/binned_spectrum_series.py
+++ b/threeML/utils/time_series/binned_spectrum_series.py
@@ -13,9 +13,7 @@ class BinnedSpectrumSeries(TimeSeries):
 
     def __init__(self,binned_spectrum_set,first_channel=1, ra=None, dec=None,
                  mission=None, instrument=None, verbose=True):
-        # type: (BinnedSpectrumSet, int, str, float, float, str, str, bool) -> None
         """
-
         :param binned_spectrum_set:
         :param first_channel:
         :param rsp_file:
@@ -144,10 +142,36 @@ class BinnedSpectrumSeries(TimeSeries):
 
         for idx in np.where(bins)[0]:
 
+            # sum over channels because we just want the total counts
+
             total_counts += self._binned_spectrum_set[idx].counts.sum()
 
 
         return total_counts
+
+
+    def count_per_channel_over_interval(self, start, stop):
+        """
+        return the number of counts in the selected interval
+        :param start: start of interval
+        :param stop:  stop of interval
+        :return:
+        """
+
+        # this will be a boolean list and the sum will be the
+        # number of events
+
+        bins = self._select_bins(start, stop)
+
+        total_counts = np.zeros(self._n_channels)
+
+        for idx in np.where(bins)[0]:
+
+            # don't sum over channels because we want the spectrum
+            total_counts += self._binned_spectrum_set[idx].counts
+
+        return total_counts
+
 
     def _select_bins(self, start, stop):
         """

--- a/threeML/utils/time_series/event_list.py
+++ b/threeML/utils/time_series/event_list.py
@@ -328,6 +328,24 @@ class EventList(TimeSeries):
 
         return self._select_events(start, stop).sum()
 
+    def count_per_channel_over_interval(self, start, stop):
+
+        channels = range(self._first_channel, self._n_channels + self._first_channel)
+
+        counts_per_channel = np.zeros(len(channels))
+
+        selection = self._select_events(start,stop)
+
+        for i, channel in enumerate(channels):
+            channel_mask = self._energies[selection] == channel
+
+            counts_per_channel[i] += channel_mask.sum()
+
+
+        return counts_per_channel
+
+
+
     def _select_events(self, start, stop):
         """
         return an index of the selected events

--- a/threeML/utils/time_series/time_series.py
+++ b/threeML/utils/time_series/time_series.py
@@ -1,18 +1,16 @@
-__author__='grburgess'
+__author__ = 'grburgess'
 
 import collections
-import copy
+import os
 
 import numpy as np
-import os
 import pandas as pd
 from pandas import HDFStore
 
 from threeML.exceptions.custom_exceptions import custom_warnings
 from threeML.io.file_utils import sanitize_filename
-
 from threeML.utils.spectrum.binned_spectrum import Quality
-from threeML.utils.time_interval import TimeIntervalSet, TimeInterval
+from threeML.utils.time_interval import TimeIntervalSet
 from threeML.utils.time_series.polynomial import polyfit, unbinned_polyfit, Polynomial
 
 
@@ -34,7 +32,7 @@ def ceildiv(a, b):
 
 
 class TimeSeries(object):
-    def __init__(self, start_time,stop_time, n_channels ,native_quality=None,
+    def __init__(self, start_time, stop_time, n_channels, native_quality=None,
                  first_channel=1, ra=None, dec=None, mission=None, instrument=None, verbose=True):
         """
         The EventList is a container for event data that is tagged in time and in PHA/energy. It handles event selection,
@@ -63,20 +61,21 @@ class TimeSeries(object):
         self._first_channel = first_channel
         self._native_quality = native_quality
 
-
         # we haven't made selections yet
 
         self._time_intervals = None
         self._poly_intervals = None
         self._counts = None
+        self._exposure = None
         self._poly_counts = None
-        self._poly_count_err= None
-
+        self._poly_count_err = None
+        self._poly_selected_counts= None
+        self._poly_exposure = None
 
         if native_quality is not None:
-
-            assert len(native_quality) == n_channels, "the native quality has length %d but you specified there were %d channels"%(len(native_quality), n_channels)
-
+            assert len(
+                native_quality) == n_channels, "the native quality has length %d but you specified there were %d channels" % (
+            len(native_quality), n_channels)
 
         self._start_time = start_time
 
@@ -103,8 +102,6 @@ class TimeSeries(object):
         else:
 
             self._mission = mission
-
-
 
         self._user_poly_order = -1
         self._time_selection_exists = False
@@ -222,8 +219,6 @@ class TimeSeries(object):
 
             raise RuntimeError('This EventList has no binning specified')
 
-  
-
     def __set_poly_order(self, value):
         """ Set poly order only in allowed range and redo fit """
 
@@ -290,7 +285,6 @@ class TimeSeries(object):
 
         raise RuntimeError("Must be implemented in sub class")
 
-
     def count_per_channel_over_interval(self, start, stop):
         """
 
@@ -298,7 +292,6 @@ class TimeSeries(object):
         :param stop:
         :return:
         """
-
 
         raise RuntimeError("Must be implemented in sub class")
 
@@ -336,9 +329,11 @@ class TimeSeries(object):
 
         new_intervals = []
 
-        for i,time_interval in enumerate(poly_intervals):
+        self._poly_selected_counts = []
 
+        self._poly_exposure = 0.
 
+        for i, time_interval in enumerate(poly_intervals):
 
             t1 = time_interval.start_time
             t2 = time_interval.stop_time
@@ -348,42 +343,36 @@ class TimeSeries(object):
                     "The time interval %f-%f is out side of the arrival times and will be dropped" % (
                         t1, t2))
 
-              
+
 
 
             else:
 
                 if t1 < self._start_time:
-
                     custom_warnings.warn(
                         "The time interval %f-%f started before the first arrival time (%f), so we are changing the intervals to %f-%f" % (
-                        t1, t2, self._start_time, self._start_time, t2))
+                            t1, t2, self._start_time, self._start_time, t2))
 
-                    t1 = self._start_time# + 1
-
-
-
-
+                    t1 = self._start_time  # + 1
 
                 if t2 > self._stop_time:
-
                     custom_warnings.warn(
                         "The time interval %f-%f ended after the last arrival time (%f), so we are changing the intervals to %f-%f" % (
                             t1, t2, self._stop_time, t1, self._stop_time))
 
-                    t2 = self._stop_time# - 1.
+                    t2 = self._stop_time  # - 1.
+
+                new_intervals.append('%f-%f' % (t1, t2))
 
 
-
-
-
-
-                new_intervals.append('%f-%f' %(t1,t2))
-
+                self._poly_selected_counts.append(self.count_per_channel_over_interval(t1,t2))
+                self._poly_exposure += self.exposure_over_interval(t1,t2)
 
         # make new intervals after checks
 
         poly_intervals = TimeIntervalSet.from_strings(*new_intervals)
+
+        self._poly_selected_counts = np.sum(self._poly_selected_counts, axis=0)
 
         # set the poly intervals as an attribute
 
@@ -414,7 +403,6 @@ class TimeSeries(object):
         # recalculate the selected counts
 
         if self._time_selection_exists:
-
             self.set_active_time_intervals(*self._time_intervals.to_string().split(','))
 
     def get_information_dict(self, use_poly=False, extract=False):
@@ -428,8 +416,15 @@ class TimeSeries(object):
 
         if extract:
 
-            pass
-        
+            is_poisson = True
+
+            counts_err = None
+            counts = self._poly_selected_counts
+            rates = self._counts / self._poly_exposure
+            rate_err = None
+            exposure = self._poly_exposure
+
+
         elif use_poly:
 
             is_poisson = False
@@ -438,6 +433,7 @@ class TimeSeries(object):
             counts = self._poly_counts
             rate_err = self._poly_count_err / self._exposure
             rates = self._poly_counts / self._exposure
+            exposure = self._exposure
 
             # removing negative counts
 
@@ -458,6 +454,7 @@ class TimeSeries(object):
             rates = self._counts / self._exposure
             rate_err = None
 
+            exposure = self._exposure
 
         if self._native_quality is None:
 
@@ -490,10 +487,10 @@ class TimeSeries(object):
             container_dict['quality'] = Quality.from_ogip(quality)
 
         # TODO: make sure the grouping makes sense
-        container_dict['backfile']='NONE'
+        container_dict['backfile'] = 'NONE'
         container_dict['grouping'] = np.ones(self._n_channels)
-        container_dict['exposure'] = self._exposure
-        #container_dict['response'] = self._response
+        container_dict['exposure'] = exposure
+        # container_dict['response'] = self._response
 
         return container_dict
 
@@ -502,7 +499,6 @@ class TimeSeries(object):
         Examine the currently selected info as well other things.
 
         """
-
 
         return self._output().to_string()
 
@@ -586,14 +582,12 @@ class TimeSeries(object):
         # Fit the sum of all the channels to determine the optimal polynomial
         # grade
 
-
         min_grade = 0
         max_grade = 4
         log_likelihoods = []
 
         t_start = self._poly_intervals.start_times
         t_stop = self._poly_intervals.stop_times
-
 
         for grade in range(min_grade, max_grade + 1):
             polynomial, log_like = unbinned_polyfit(events, grade, t_start, t_stop, exposure)
@@ -638,10 +632,7 @@ class TimeSeries(object):
 
         filename = os.path.splitext(filename)
 
-
-
         filename = "%s.h5" % filename[0]
-
 
         filename_sanitized = sanitize_filename(filename)
 
@@ -685,27 +676,22 @@ class TimeSeries(object):
             df_coeff.to_hdf(store, 'coefficients')
             df_err.to_hdf(store, 'covariance')
 
-
-
             store.get_storer('coefficients').attrs.metadata = {'poly_order': self._optimal_polynomial_grade,
-                                                               'poly_selections': zip(self._poly_intervals.start_times,self._poly_intervals.stop_times),
-                                                               'unbinned':self._unbinned,
-                                                               'fit_method':self._fit_method_info['fit method']}
+                                                               'poly_selections': zip(self._poly_intervals.start_times,
+                                                                                      self._poly_intervals.stop_times),
+                                                               'unbinned': self._unbinned,
+                                                               'fit_method': self._fit_method_info['fit method']}
 
         if self._verbose:
-
-            print("\nSaved fitted background to %s.\n"% filename)
+            print("\nSaved fitted background to %s.\n" % filename)
 
     def restore_fit(self, filename):
-
 
         filename_sanitized = sanitize_filename(filename)
 
         with HDFStore(filename_sanitized) as store:
 
             coefficients = store['coefficients']
-
-
 
             covariance = store['covariance']
 
@@ -714,7 +700,6 @@ class TimeSeries(object):
             # create new polynomials
 
             for i in range(len(coefficients)):
-
                 coeff = np.array(coefficients.loc[i])
 
                 # make sure we get the right order
@@ -723,22 +708,16 @@ class TimeSeries(object):
 
                 coeff = coeff[np.isfinite(coeff)]
 
-                cov  = covariance.loc[i]
-
-
+                cov = covariance.loc[i]
 
                 self._polynomials.append(Polynomial.from_previous_fit(coeff, cov))
-
-
-
-
 
             metadata = store.get_storer('coefficients').attrs.metadata
 
             self._optimal_polynomial_grade = metadata['poly_order']
             poly_selections = np.array(metadata['poly_selections'])
 
-            self._poly_intervals = TimeIntervalSet.from_starts_and_stops(poly_selections[:,0],poly_selections[:,1])
+            self._poly_intervals = TimeIntervalSet.from_starts_and_stops(poly_selections[:, 0], poly_selections[:, 1])
             self._unbinned = metadata['unbinned']
 
             if self._unbinned:
@@ -750,13 +729,11 @@ class TimeSeries(object):
 
             self._fit_method_info['fit method'] = metadata['fit_method']
 
-
         # go thru and count the counts!
 
         self._poly_fit_exists = True
 
         if self._time_selection_exists:
-
             self.set_active_time_intervals(*self._time_intervals.to_string().split(','))
 
     def view_lightcurve(self, start=-10, stop=20., dt=1., use_binner=False):

--- a/threeML/utils/time_series/time_series.py
+++ b/threeML/utils/time_series/time_series.py
@@ -290,6 +290,18 @@ class TimeSeries(object):
 
         raise RuntimeError("Must be implemented in sub class")
 
+
+    def count_per_channel_over_interval(self, start, stop):
+        """
+
+        :param start:
+        :param stop:
+        :return:
+        """
+
+
+        raise RuntimeError("Must be implemented in sub class")
+
     def set_polynomial_fit_interval(self, *time_intervals, **options):
         """Set the time interval to fit the background.
         Multiple intervals can be input as separate arguments
@@ -405,7 +417,7 @@ class TimeSeries(object):
 
             self.set_active_time_intervals(*self._time_intervals.to_string().split(','))
 
-    def get_information_dict(self, use_poly=False):
+    def get_information_dict(self, use_poly=False, extract=False):
         """
         Return a PHAContainer that can be read by different builders
 
@@ -414,7 +426,11 @@ class TimeSeries(object):
         if not self._time_selection_exists:
             raise RuntimeError('No time selection exists! Cannot calculate rates')
 
-        if use_poly:
+        if extract:
+
+            pass
+        
+        elif use_poly:
 
             is_poisson = False
 


### PR DESCRIPTION
This allows for the extraction of the selected background interval's counts rather than using the polynomial modeled counts. The choice comes at the point of creation of the plugin. All the identifiers  in the background spectrum are set automatically and the background exposure is properly scaled. 