### PR TITLE
fix a small bug at 611 which crashes with older version of liff

### DIFF
--- a/threeML/plugins/HAWCLike.py
+++ b/threeML/plugins/HAWCLike.py
@@ -608,7 +608,7 @@ class HAWCLike(PluginPrototype):
             pixels_per_bin =  np.array( self._theLikeHAWC.GetNumberOfPixels() )
             return int(np.sum( pixels_per_bin ))
         except AttributeError:
-            warnings.warn(
+            custom_warnings.warn(
               "_theLikeHAWC.GetNumberOfPixels() not available, values for statistical measurements such as AIC or BIC are unreliable. Please update your aerie version." )
             return 1
 


### PR DESCRIPTION
Change "warning" to "custom_warning" at L611 since "warning" is not imported. With older version of liff (for the Geminga paper), the code will definitely execute this line and crash.