### PR TITLE
Set active measurements list

### DIFF
--- a/threeML/plugins/HAWCLike.py
+++ b/threeML/plugins/HAWCLike.py
@@ -208,9 +208,16 @@ class HAWCLike(PluginPrototype):
                              "will not be effective until you create a new JointLikelihood or Bayesian" +
                              "instance")
 
-    def set_active_measurements(self, minChannel, maxChannel):
+    def set_active_measurements(self, minChannel=None, maxChannel=None, bin_list=None):
     
-        self.set_bin_list(self._min_and_max_to_list(minChannel, maxChannel))
+        if bin_list is not None:
+            assert minChannel is None and maxChannel is None, 'bin_list provided, thus neither minChannel nor ' \
+                'maxChannel should be set'
+            self.set_bin_list(bin_list)
+        else:
+            assert minChannel is not None and maxChannel is not None, 'bin_list not provided, thus both minChannel ' \
+                'and maxChannel should be set'
+            self.set_bin_list(self._min_and_max_to_list(minChannel, maxChannel))
 
     def set_model(self, likelihood_model_instance):
         """

--- a/threeML/test/test_hawc.py
+++ b/threeML/test/test_hawc.py
@@ -104,6 +104,23 @@ def hawc_point_source_fitted_joint_like():
 
 
 @skip_if_hawc_is_not_available
+def test_set_active_measurements():
+
+    data_path = sanitize_filename(os.environ.get('HAWC_3ML_TEST_DATA_DIR'), abspath=True)
+
+    maptree = os.path.join(data_path, _maptree_name)
+    response = os.path.join(data_path, _response_name)
+
+    assert os.path.exists(maptree) and os.path.exists(response), "Data files do not exist at %s" % data_path
+
+    llh = HAWCLike("HAWC", maptree, response)
+    # Test one way
+    llh.set_active_measurements(1, 9)
+    # Test the other way
+    llh.set_active_measurements(bin_list=['4','5','6','7','8','9'])
+
+
+@skip_if_hawc_is_not_available
 def test_hawc_fullsky_options():
 
     assert is_plugin_available("HAWCLike"), "HAWCLike is not available!"


### PR DESCRIPTION
Add a `bin_list` option to set_active_measurements(), similar to the behavior in the hawc_hal plugin.