### PR TITLE
Bugfix in plot color, and catch other cases.

### DIFF
--- a/threeML/io/plotting/model_plot.py
+++ b/threeML/io/plotting/model_plot.py
@@ -125,7 +125,7 @@ def plot_point_source_spectra(*analysis_results, **kwargs):
         else:
 
             # duck typing
-            if isinstance(_defaults['fit_colors'], str):
+            if isinstance(_defaults['fit_colors'], (str, unicode)):
 
                 color_fit = [_defaults['fit_colors']] * num_sources_to_plot
 
@@ -137,6 +137,10 @@ def plot_point_source_spectra(*analysis_results, **kwargs):
 
                 color_fit = _defaults['fit_colors']
 
+            else:
+                raise ValueError('Can not setup color, wrong type:', type(_defaults['fit_colors']))
+
+
         if _defaults['contour_colors'] is None:
 
             color_contour = cmap_intervals(num_sources_to_plot + 1, _defaults['contour_cmap'])
@@ -144,7 +148,7 @@ def plot_point_source_spectra(*analysis_results, **kwargs):
         else:
 
             # duck typing
-            if isinstance(_defaults['contour_colors'], str):
+            if isinstance(_defaults['contour_colors'], (str, unicode)):
 
                 color_contour = [_defaults['contour_colors']] * num_sources_to_plot
 
@@ -155,6 +159,9 @@ def plot_point_source_spectra(*analysis_results, **kwargs):
                         len(_defaults['contour_colors']), num_sources_to_plot)
 
                 color_contour = _defaults['fit_colors']
+
+            else:
+                raise ValueError('Can not setup contour color, wrong type:', type(_defaults['contour_colors']))
 
         color_itr = 0
 


### PR DESCRIPTION
The color option did not work for me. My color was a unicode string, which was not in the `isinstance` test. So the `color_fit` variable was not set, ending up in a crash.
Now, I look for unicode type too. And if none of the `isinstance` test succeed, I raise an error right away rather than postponing the crash.
I added 4 lines of uncovered code, but that's better than the previous situation where the `else` was not present.