### PR TITLE
free_point_sources_within_radius() in Fermi.py

### DIFF
--- a/threeML/catalogs/Fermi.py
+++ b/threeML/catalogs/Fermi.py
@@ -597,8 +597,8 @@ class ModelFrom3FGL(Model):
 
                 else:
 
-                    for par in src.spectrum.main.parameters:
-                        src.spectrum.main.parameters[par].free = free
+                    for par in src.spectrum.main.shape.parameters:
+                        src.spectrum.main.shape.parameters[par].free = free
 
 
 class FermiLATSourceCatalog(VirtualObservatoryCatalog):


### PR DESCRIPTION
src.spectrum.main.parameters --> src.spectrum.main.shape.parameters
for freeing parameters other than normalization 