### PR TITLE
Sorting tte data

### DIFF
--- a/threeML/utils/binner.py
+++ b/threeML/utils/binner.py
@@ -528,7 +528,7 @@ class TemporalBinner(TimeIntervalSet):
 
             if 'duplicate' in str(e):
 
-                warnings.warn('There where possible duplicate time tags in the data. We will try to run a different algorithm')
+                custom_warnings.warn('There where possible duplicate time tags in the data. We will try to run a different algorithm')
             
                 final_edges = bayesian_blocks_not_unique(arrival_times, arrival_times[0], arrival_times[-1], p0)
 

--- a/threeML/utils/binner.py
+++ b/threeML/utils/binner.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from threeML.io.progress_bar import progress_bar
-from threeML.utils.bayesian_blocks import bayesian_blocks
+from threeML.utils.bayesian_blocks import bayesian_blocks, bayesian_blocks_not_unique
 from threeML.utils.statistics.stats_tools import Significance
 from threeML.utils.time_interval import TimeIntervalSet
 
@@ -520,8 +520,19 @@ class TemporalBinner(TimeIntervalSet):
 
         """
 
-        final_edges = bayesian_blocks(arrival_times, arrival_times[0], arrival_times[-1], p0, bkg_integral_distribution)
+        try:
+        
+            final_edges = bayesian_blocks(arrival_times, arrival_times[0], arrival_times[-1], p0, bkg_integral_distribution)
 
+        except Exception as e:
+
+            if 'duplicate' in str(e):
+
+                warnings.warn('There where possible duplicate time tags in the data. We will try to run a different algorithm')
+            
+                final_edges = bayesian_blocks_not_unique(arrival_times, arrival_times[0], arrival_times[-1], p0)
+
+            
         starts = np.asarray(final_edges)[:-1]
         stops = np.asarray(final_edges)[1:]
 

--- a/threeML/utils/binner.py
+++ b/threeML/utils/binner.py
@@ -4,7 +4,7 @@ from threeML.io.progress_bar import progress_bar
 from threeML.utils.bayesian_blocks import bayesian_blocks, bayesian_blocks_not_unique
 from threeML.utils.statistics.stats_tools import Significance
 from threeML.utils.time_interval import TimeIntervalSet
-
+from threeML.exceptions.custom_exceptions import custom_warnings
 
 class NotEnoughData(RuntimeError):
     pass

--- a/threeML/utils/data_builders/fermi/gbm_data.py
+++ b/threeML/utils/data_builders/fermi/gbm_data.py
@@ -35,10 +35,10 @@ class GBMTTEFile(object):
         # but first we must check that there are NO duplicated events
         # and then warn the user
 
-         if not len(self._events) == len(np.unique(self._events)):
+        if not len(self._events) == len(np.unique(self._events)):
 
 
-             warnings.warn('The TTE file %s contains duplicate time tags and is thus invalid. Contact the FSSC ' % ttefile)
+            warnings.warn('The TTE file %s contains duplicate time tags and is thus invalid. Contact the FSSC ' % ttefile)
 
         
         

--- a/threeML/utils/data_builders/fermi/gbm_data.py
+++ b/threeML/utils/data_builders/fermi/gbm_data.py
@@ -35,7 +35,10 @@ class GBMTTEFile(object):
         # but first we must check that there are NO duplicated events
         # and then warn the user
 
-        assert len(self._events) == len(np.unique(self._events)), 'The TTE file %s contains duplicate time tags and is thus invalid. Contact the FSSC ' % ttefile
+         if not len(self._events) == len(np.unique(self._events)):
+
+
+             warnings.warn('The TTE file %s contains duplicate time tags and is thus invalid. Contact the FSSC ' % ttefile)
 
         
         

--- a/threeML/utils/data_builders/fermi/gbm_data.py
+++ b/threeML/utils/data_builders/fermi/gbm_data.py
@@ -31,13 +31,24 @@ class GBMTTEFile(object):
         # we will now do this for you. We should at some
         # point check with NASA if this is on purpose.
 
+
+        # but first we must check that there are NO duplicated events
+        # and then warn the user
+
+        assert len(self._events) == len(np.unique(self._events)), 'The TTE file %s contains duplicate time tags and is thus invalid. Contact the FSSC ' % ttefile
+
+        
+        
         # sorting in time
         sort_idx = self._events.argsort()
 
-        # now sort both time and energy
 
-        self._events = self._events[sort_idx]
-        self._pha = self._pha[sort_idx]
+        if not np.alltrue(self._events[sort_idx] == self._events):
+        
+            # now sort both time and energy
+            warnings.warn('The TTE file %s was not sorted in time but contains no duplicate events. We will sort the times, but use caution with this file. Contact the FSSC.')
+            self._events = self._events[sort_idx]
+            self._pha = self._pha[sort_idx]
         
         
         try:

--- a/threeML/utils/data_builders/fermi/gbm_data.py
+++ b/threeML/utils/data_builders/fermi/gbm_data.py
@@ -27,6 +27,19 @@ class GBMTTEFile(object):
         self._events = tte['EVENTS'].data['TIME']
         self._pha = tte['EVENTS'].data['PHA']
 
+        # the GBM TTE data are not always sorted in TIME.
+        # we will now do this for you. We should at some
+        # point check with NASA if this is on purpose.
+
+        # sorting in time
+        sort_idx = self._events.argsort()
+
+        # now sort both time and energy
+
+        self._events = self._events[sort_idx]
+        self._pha = self._pha[sort_idx]
+        
+        
         try:
             self._trigger_time = tte['PRIMARY'].header['TRIGTIME']
 


### PR DESCRIPTION
I found some bugs in TTE data which caused Bayesian blocks to fail At first I thought it was just sorting, but it is actually that a lot of files have duplicate time tags which means the files are corrupt.

I've now added a check for duplicate time tags which will cause an assertion error. If there are no duplicates and the data are still not sorted, a warning is issued and we sort the time for the user. 