### PR TITLE
Verbose hotfix

### DIFF
--- a/threeML/plugins/OGIPLike.py
+++ b/threeML/plugins/OGIPLike.py
@@ -162,4 +162,4 @@ class OGIPLike(DispersionSpectrumLike):
         else:
             background_pha = PHASpectrum.from_dispersion_spectrum(background, file_type='background')
 
-        return cls(dispersion_like.name, observation=observed_pha, background=background_pha)
+        return cls(dispersion_like.name, observation=observed_pha, background=background_pha, verbose=False)


### PR DESCRIPTION
When writing fits files from time series, we do not need to see 100 messages from the OGIP constructor. This shuts them up.